### PR TITLE
`.write()`: change signature to take a closure that modifies the reset

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,8 +186,12 @@ pub fn gen_register(cx: &ExtCtxt, r: &Register, d: &Defaults) -> Vec<P<Item>> {
 
             items.push(quote_item!(cx,
                                    impl $name {
-                                       pub fn write(&self, value: $name_w) {
-                                           self.register.write(value.bits);
+                                       pub fn write<F>(&self, f: F)
+                                           where F: FnOnce(&mut $name_w) -> &mut $name_w,
+                                       {
+                                           let mut w = $name_w::reset_value();
+                                           f(&mut w);
+                                           self.register.write(w.bits);
                                        }
                                    })
                 .unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,8 +167,12 @@ pub fn gen_register(cx: &ExtCtxt, r: &Register, d: &Defaults) -> Vec<P<Item>> {
                                            $name_r { bits: self.register.read() }
                                        }
 
-                                       pub fn write(&mut self, value: $name_w) {
-                                           self.register.write(value.bits)
+                                       pub fn write<F>(&mut self, f: F)
+                                           where F: FnOnce(&mut $name_w) -> &mut $name_w,
+                                       {
+                                           let mut w = $name_w::reset_value();
+                                           f(&mut w);
+                                           self.register.write(w.bits);
                                        }
                                    })
                 .unwrap());


### PR DESCRIPTION
value

closes #2