### PR TITLE
Fix overflow for width==32

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,8 +227,8 @@ pub fn gen_register_r(r: &Register, d: &Defaults) -> Vec<Tokens> {
             }
         } else {
             let width_ty = width.to_ty();
-            let mask: u32 = (1 << width) - 1;
-            let mask = Lit::Int(u64::from(mask), IntTy::Unsuffixed);
+            let mask: u64 = (1 << width) - 1;
+            let mask = Lit::Int(mask, IntTy::Unsuffixed);
 
             quote! {
                 pub fn #name(&self) -> #width_ty {
@@ -314,8 +314,8 @@ pub fn gen_register_w(r: &Register, d: &Defaults) -> Vec<Tokens> {
             }
         } else {
             let width_ty = width.to_ty();
-            let mask: u32 = (1 << width) - 1;
-            let mask = Lit::Int(u64::from(mask), IntTy::Unsuffixed);
+            let mask = (1 << width) - 1;
+            let mask = Lit::Int(mask, IntTy::Unsuffixed);
 
             quote! {
                 pub fn #name(&mut self, value: #width_ty) -> &mut Self {


### PR DESCRIPTION
If `width == 32` the left shift overflows, which causes a panic in debug mode. In order to fix this, we increase the mask size to `u64`.

[wrapping_shl](https://doc.rust-lang.org/nightly/std/primitive.u32.html#method.wrapping_shl) doesn't work here since it “removes any high-order bits of rhs that would cause the shift to exceed the bitwidth of the type”. So `1.wrapping_shl(32)` becomes `1.wrapping_shl(0)`, which leads to the wrong mask.