### PR TITLE
Match peripheral name exactly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,17 +41,17 @@ fn main() {
             }
         }
         Some(pattern) => {
-            for peripheral in &d.peripherals {
-                if peripheral.name.to_ascii_lowercase().contains(&pattern) {
-                    println!("{}",
-                             svd2rust::gen_peripheral(peripheral, &d.defaults)
-                                 .iter()
-                                 .map(|i| i.to_string())
-                                 .collect::<Vec<_>>()
-                                 .join("\n\n"));
+            if let Some(peripheral) = d.peripherals
+                .iter()
+                .find(|x| x.name.to_ascii_lowercase() == pattern)
+                .or(d.peripherals.iter().find(|x| x.name.to_ascii_lowercase().contains(&pattern))) {
+                println!("{}",
+                         svd2rust::gen_peripheral(peripheral, &d.defaults)
+                             .iter()
+                             .map(|i| i.to_string())
+                             .collect::<Vec<_>>()
+                             .join("\n\n"));
 
-                    break;
-                }
             }
         }
     }


### PR DESCRIPTION
Match peripheral name exactly to prevent specification of peripheral such as tim1 accidentally returning peripheral details for tim15 for
instance.