### PR TITLE
Sort registers by address_offset before checking for overlap.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,11 @@ pub fn gen_peripheral(p: &Peripheral, d: &Defaults) -> Vec<Tokens> {
     let registers = p.registers
         .as_ref()
         .expect(&format!("{:#?} has no `registers` field", p));
-    for register in registers {
+
+    let mut registers: Vec<&Register> = registers.iter().collect();
+    registers.sort_by_key(|x| x.address_offset);
+
+    for register in registers.iter() {
         let pad = if let Some(pad) = register.address_offset
             .checked_sub(offset) {
             pad


### PR DESCRIPTION
This was a problem for example when generating the map for NVIC on the STM32F303x, where
most registers would be discarded because STIR is listed first, before all ISERx fields.