### PR TITLE
gen_register_w: always cast the reset value to the correct type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,7 @@ impl SanitizeName for String {
     fn sanitize(&self) -> String {
         match self.as_str() {
             "fn" => "fn_".to_owned(),
+            "in" => "in_".to_owned(),
             "match" => "match_".to_owned(),
             "mod" => "mod_".to_owned(),
             _ => self.to_owned(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,7 +563,7 @@ pub fn gen_register_w(r: &Register, d: &Defaults) -> Vec<Tokens> {
         impl_items.push(quote! {
             /// Reset value
             pub fn reset_value() -> Self {
-                #name { bits: #reset_value }
+                #name { bits: #reset_value as #bits_ty}
             }
         });
     }


### PR DESCRIPTION
It may happen that a register (e.g. the WDT CTRL register of Atmel ATSAMD21E17)
does not have the reset value specified.  In such cases the default
value 0u32 will be used.  However, if the register width is not 32 (as
is the case with the above mentioned WDT CTRL), rustc will complain.

So always cast the default value to the type that corresponds to the
register's width.