### PR TITLE
fix reset_value bitness

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,7 +559,9 @@ pub fn gen_register_w(r: &Register, d: &Defaults) -> Vec<Tokens> {
 
     let mut impl_items = vec![];
 
-    if let Some(reset_value) = r.reset_value.or(d.reset_value) {
+    if let Some(reset_value) = r.reset_value
+            .or(d.reset_value)
+            .map(|x| Lit::Int(x as u64, IntTy::Unsuffixed)) {
         impl_items.push(quote! {
             /// Reset value
             pub fn reset_value() -> Self {


### PR DESCRIPTION
reset_value is by default output as u32, which sometimes disagrees with the width of the register itself causing a type error on compilation. Patch just removes the u32 suffix. 