### PR TITLE
enum based API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "either 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "inflections 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "svd-parser 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "svd-parser 0.2.0 (git+https://github.com/japaric/svd?branch=enumerated-values)",
  "syn 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -72,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "svd-parser"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/japaric/svd?branch=enumerated-values#261a64f70ac2b40f22bffc6a194c2d8151ba92a8"
 dependencies = [
  "xmltree 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -152,7 +152,7 @@ dependencies = [
 "checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
 "checksum quote 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6732e32663c9c271bfc7c1823486b471f18c47a2dbf87c066897b7b51afc83be"
 "checksum strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "67f84c44fbb2f91db7fef94554e6b2ac05909c9c0b0bc23bb98d3a1aebfe7f7c"
-"checksum svd-parser 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b40488b057aa79b7134dfe50fb81d98553c59de6996be2a1fd62b929697a26e4"
+"checksum svd-parser 0.2.0 (git+https://github.com/japaric/svd?branch=enumerated-values)" = "<none>"
 "checksum syn 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "76c2db66dc579998854d84ff0ff4a81cb73e69596764d144ce7cece4d04ce6b5"
 "checksum term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7f5f3f71b0040cecc71af239414c23fd3c73570f5ff54cf50e03cef637f2a0"
 "checksum unicode-segmentation 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c3bc443ded17b11305ffffe6b37e2076f328a5a8cb6aa877b1b98f77699e98b5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,9 @@ clap = "2.14.0"
 either = "1.0.2"
 inflections = "1.0.0"
 quote = "0.3.3"
-svd-parser = "0.2.0"
+# svd-parser = "0.3.0"
 syn = "0.9"
+
+[dependencies.svd-parser]
+branch = "enumerated-values"
+git = "https://github.com/japaric/svd"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -775,7 +775,7 @@ pub fn gen_register_r(r: &Register,
                     .collect::<Vec<_>>();
 
                 items.push(quote! {
-                    #[derive(Clone, Copy, Eq, PartialEq)]
+                    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
                     pub enum #name_e {
                         #(#variants)*
                     }
@@ -947,7 +947,7 @@ pub fn gen_register_w(r: &Register,
                         .collect::<Vec<_>>();
 
                 items.push(quote! {
-                    #[derive(Clone, Copy, Eq, PartialEq)]
+                    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
                     pub enum #name_e {
                         #(#variants)*
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -732,7 +732,6 @@ pub fn gen_register_r(r: &Register,
                                                     .to_pascal_case())));
             if base.is_none() {
                 let mut variants = vec![];
-                let mut j = 0;
                 let arms = (0..(1 << width))
                     .map(|i| {
                         let (variant, doc, reserved) = if let Some(evalue) =
@@ -745,8 +744,7 @@ pub fn gen_register_r(r: &Register,
 
                             (Cow::from(variant), doc, false)
                         } else {
-                            let variant = format!("_Reserved{:b}", j);
-                            j += 1;
+                            let variant = format!("_Reserved{:b}", i);
 
                             (Cow::from(variant), None, true)
                         };


### PR DESCRIPTION
Auto-generated API for reads looks like this:

``` rust
impl Out {
    pub fn read(&self) -> OutR {
        OutR { bits: self.register.read() }
    }

    ..
}

#[derive(Clone , Copy)]
#[repr(C) ]
pub struct OutR {
    bits: u32,
}

impl OutR {
    #[doc = "Bit 0 - Pin 0."]
    pub fn pin0(&self) -> OutRPin0 {
        const MASK: u32 = 1;
        const OFFSET: u8 = 0u8;
        OutRPin0::from((self.bits >> OFFSET) & MASK)
    }
    
    ..
}

#[derive(Clone, Copy, Eq, PartialEq)]
pub enum OutRPin0 {
    #[ doc = "Pin driver is low." ]
    Low,
    #[ doc = "Pin driver is high." ]
    High,
}

impl OutRPin0 {
    #[inline(always)]
    fn from(value: u32) -> Self {
        match value {
            0u32 => OutRPin0::Low,
            1u32 => OutRPin0::High,
            _ => unreachable!(),
        }
    }
}
```

The `unreachable!()` will get optimized away when compiling in release mode.

In the case where a bitfield is e.g. 2 bits wide but the SVD file lists less than 4 values / variants, svd2rust will create hidden reserved variants:

``` rust
#[derive(Clone, Copy, Eq, PartialEq)]
pub enum PinCnfRPull {
    #[doc = "No pull."]
    Disabled,
    #[doc = "Pulldown on pin."]
    Pulldown,
    #[doc(hidden)]
    _Reserved10,
    #[doc = "Pullup on pin."]
    Pullup,
}
```

In the above example, the value `0b10` was not listed in [the SVD](https://github.com/posborne/cmsis-svd/blob/master/data/Nordic/nrf51.svd).

---

Auto-generated API for writes looks like this:

``` rust
impl Out {
    pub fn write<F>(&mut self, f: F)
        where F: FnOnce(&mut OutW) -> &mut OutW
    {
        let mut w = OutW::reset_value();
        f(&mut w);
        self.register.write(w.bits);
    }
    ..
}

#[derive(Clone , Copy)]
#[repr(C)]
pub struct OutW {
    bits: u32,
}

impl OutW {
    #[doc = "Bit 0 - Pin 0."]
    pub fn pin0(&mut self, value: OutWPin0) -> &mut Self {
        const MASK: u32 = 1;
        const OFFSET: u8 = 0u8;
        self.bits &= !((MASK as u32) << OFFSET);
        self.bits |= value.bits() << OFFSET;
        self
    }
    
    ..
}


#[derive(Clone, Copy, Eq, PartialEq)]
pub enum OutWPin0 {
    # [ doc = "Pin driver is low." ]
    Low,
    # [ doc = "Pin driver is high." ]
    High,
}

impl OutWPin0 {
    # [ inline ( always ) ]
    fn bits(&self) -> u32 {
        match *self {
            OutWPin0::Low => 0u32,
            OutWPin0::High => 1u32,
        }
    }
}
```

---

The `modify` API remains unchanged.

To get an idea of what actually *using* this API looks like, check [this PR].

[this PR]: https://github.com/japaric/nrf51822/pull/4 

cc @brandonedens 