### PR TITLE
enum based API (alternative write API)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "either 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "inflections 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "svd-parser 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "svd-parser 0.2.0 (git+https://github.com/japaric/svd?branch=enumerated-values)",
  "syn 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -72,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "svd-parser"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/japaric/svd?branch=enumerated-values#261a64f70ac2b40f22bffc6a194c2d8151ba92a8"
 dependencies = [
  "xmltree 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -152,7 +152,7 @@ dependencies = [
 "checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
 "checksum quote 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6732e32663c9c271bfc7c1823486b471f18c47a2dbf87c066897b7b51afc83be"
 "checksum strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "67f84c44fbb2f91db7fef94554e6b2ac05909c9c0b0bc23bb98d3a1aebfe7f7c"
-"checksum svd-parser 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b40488b057aa79b7134dfe50fb81d98553c59de6996be2a1fd62b929697a26e4"
+"checksum svd-parser 0.2.0 (git+https://github.com/japaric/svd?branch=enumerated-values)" = "<none>"
 "checksum syn 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "76c2db66dc579998854d84ff0ff4a81cb73e69596764d144ce7cece4d04ce6b5"
 "checksum term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7f5f3f71b0040cecc71af239414c23fd3c73570f5ff54cf50e03cef637f2a0"
 "checksum unicode-segmentation 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c3bc443ded17b11305ffffe6b37e2076f328a5a8cb6aa877b1b98f77699e98b5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "either 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "inflections 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "svd-parser 0.2.0 (git+https://github.com/japaric/svd?branch=enumerated-values)",
+ "svd-parser 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -71,8 +71,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "svd-parser"
-version = "0.2.0"
-source = "git+https://github.com/japaric/svd?branch=enumerated-values#261a64f70ac2b40f22bffc6a194c2d8151ba92a8"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "xmltree 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -152,7 +152,7 @@ dependencies = [
 "checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
 "checksum quote 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6732e32663c9c271bfc7c1823486b471f18c47a2dbf87c066897b7b51afc83be"
 "checksum strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "67f84c44fbb2f91db7fef94554e6b2ac05909c9c0b0bc23bb98d3a1aebfe7f7c"
-"checksum svd-parser 0.2.0 (git+https://github.com/japaric/svd?branch=enumerated-values)" = "<none>"
+"checksum svd-parser 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "726fd935d2826ae574f18229e985639e0b9465f9d188e136d8f599c78b881ed1"
 "checksum syn 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "76c2db66dc579998854d84ff0ff4a81cb73e69596764d144ce7cece4d04ce6b5"
 "checksum term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7f5f3f71b0040cecc71af239414c23fd3c73570f5ff54cf50e03cef637f2a0"
 "checksum unicode-segmentation 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c3bc443ded17b11305ffffe6b37e2076f328a5a8cb6aa877b1b98f77699e98b5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,5 @@ clap = "2.14.0"
 either = "1.0.2"
 inflections = "1.0.0"
 quote = "0.3.3"
+svd-parser = "0.3.0"
 syn = "0.9"
-
-[dependencies.svd-parser]
-branch = "enumerated-values"
-git = "https://github.com/japaric/svd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,8 @@ clap = "2.14.0"
 either = "1.0.2"
 inflections = "1.0.0"
 quote = "0.3.3"
-svd-parser = "0.2.0"
 syn = "0.9"
+
+[dependencies.svd-parser]
+branch = "enumerated-values"
+git = "https://github.com/japaric/svd"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,14 +1,14 @@
 set -ex
 
 test_gen() {
-    cargo run --target $TARGET --release -- -i $td/$svd $1 > $td/src/lib.rs
+    target/$TARGET/release/svd2rust -i $td/$svd $1 > $td/src/lib.rs
     echo 'extern crate volatile_register;' >> $td/src/lib.rs
-    cargo build --manifest-path $td/Cargo.toml --target $TARGET
+    cargo build --manifest-path $td/Cargo.toml
 }
 
 main() {
-    cargo build --target $TARGET
-    cargo build --target $TARGET --release
+    cross build --target $TARGET
+    cross build --target $TARGET --release
 
     if [ ! -z $DISABLE_TESTS ]; then
         return
@@ -24,7 +24,7 @@ main() {
     esac
 
     # test crate
-    cargo init --name foo $td
+    cross init --name foo $td
     echo 'volatile-register = "0.1.0"' >> $td/Cargo.toml
 
     curl -L \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1200,6 +1200,8 @@ fn field_doc(bit_range: BitRange, doc: Option<&String>) -> String {
     let BitRange { offset, width } = bit_range;
 
     if let Some(doc) = doc {
+        let doc = respace(doc);
+
         if width == 1 {
             format!("Bit {} - {}", offset, doc)
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,7 +366,7 @@ pub fn gen_peripheral(p: &Peripheral, d: &Defaults) -> Vec<Tokens> {
         .as_ref()
         .expect(&format!("{:#?} has no `registers` field", p));
 
-    for register in expand(registers).iter() {
+    for register in &expand(registers) {
         let pad = if let Some(pad) = register.offset
             .checked_sub(offset) {
             pad
@@ -534,6 +534,7 @@ fn access(r: &Register) -> Access {
     })
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
 #[doc(hidden)]
 pub fn gen_register(r: &Register,
                     d: &Defaults,
@@ -1201,12 +1202,10 @@ fn field_doc(bit_range: BitRange, doc: Option<&String>) -> String {
         } else {
             format!("Bits {}:{} - {}", offset, offset + width - 1, doc)
         }
+    } else if width == 1 {
+        format!("Bit {}", offset)
     } else {
-        if width == 1 {
-            format!("Bit {}", offset)
-        } else {
-            format!("Bits {}:{}", offset, offset + width - 1)
-        }
+        format!("Bits {}:{}", offset, offset + width - 1)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,6 +669,10 @@ pub fn gen_register(r: &Register,
 
         if access == Access::ReadOnly || access == Access::ReadWrite {
             for field in fields {
+                if field.access == Some(Access::WriteOnly) {
+                    continue;
+                }
+
                 let field_name = Ident::new(&*field.name
                     .to_sanitized_snake_case());
                 let _field_name = Ident::new(&*format!("_{}",
@@ -838,6 +842,10 @@ pub fn gen_register(r: &Register,
 
         if access == Access::WriteOnly || access == Access::ReadWrite {
             for field in fields {
+                if field.access == Some(Access::ReadOnly) {
+                    continue;
+                }
+
                 let field_name_sc = Ident::new(&*field.name
                     .to_sanitized_snake_case());
                 let width = field.bit_range.width;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,7 +347,7 @@ use syn::*;
 
 /// List of chars that some vendors use in their peripheral/field names but
 /// that are not valid in Rust ident
-const BLACKLIST_CHARS: &[char] = &['(', ')'];
+const BLACKLIST_CHARS: &'static [char] = &['(', ')'];
 
 trait ToSanitizedPascalCase {
     fn to_sanitized_pascal_case(&self) -> Cow<str>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -925,9 +925,9 @@ pub fn gen_register(r: &Register,
                                 const OFFSET: u8 = #offset;
 
                                 self.register.bits &=
-                                    !(MASK << OFFSET) as #reg_ty;
+                                    !((MASK as #reg_ty) << OFFSET);
                                 self.register.bits |=
-                                    ((bits & MASK) << OFFSET) as #reg_ty;
+                                    ((bits & MASK) as #reg_ty) << OFFSET;
                                 self.register
                             }
                         });
@@ -939,9 +939,9 @@ pub fn gen_register(r: &Register,
                                 const OFFSET: u8 = #offset;
 
                                 self.register.bits &=
-                                    !(MASK << OFFSET) as #reg_ty;
+                                    !((MASK as #reg_ty) << OFFSET);
                                 self.register.bits |=
-                                    ((bits & MASK) << OFFSET) as #reg_ty;
+                                    ((bits & MASK) as #reg_ty) << OFFSET;
                                 self.register
                             }
                         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -888,8 +888,8 @@ pub fn gen_register(r: &Register,
                         }
                     });
 
-                    let doc = format!("Returns the value of the field {}",
-                                      field.name);
+                    let doc = field_doc(field.bit_range,
+                                        field.description.as_ref());
                     r_impl_items.push(quote! {
                         #[doc = #doc]
                         pub fn #field_name(&self) -> #name {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1023,7 +1023,10 @@ pub fn gen_register(r: &Register,
 
                         mod_items.push(quote! {
                             impl #enum_name {
-                                fn _bits(&self) -> #field_ty {
+                                #[allow(missing_docs)]
+                                #[doc(hidden)]
+                                #[inline(always)]
+                                pub fn _bits(&self) -> #field_ty {
                                     match *self {
                                         #(#arms),*
                                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -688,7 +688,7 @@ pub fn gen_register(r: &Register,
                                                        field.name
                                                            .to_snake_case()));
                 let width = field.bit_range.width;
-                let mask = Lit::Int((1u64 << width - 1), IntTy::Unsuffixed);
+                let mask = Lit::Int((1u64 << width) - 1, IntTy::Unsuffixed);
                 let offset = Lit::Int(u64::from(field.bit_range.offset),
                                       IntTy::Unsuffixed);
                 let field_ty = width.to_ty();
@@ -908,7 +908,7 @@ pub fn gen_register(r: &Register,
                 let field_name_sc = Ident::new(&*field.name
                     .to_sanitized_snake_case());
                 let width = field.bit_range.width;
-                let mask = Lit::Int((1u64 << width - 1), IntTy::Unsuffixed);
+                let mask = Lit::Int((1u64 << width) - 1, IntTy::Unsuffixed);
                 let offset = Lit::Int(u64::from(field.bit_range.offset),
                                       IntTy::Unsuffixed);
                 let field_ty = width.to_ty();

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn find_peripheral<F: Fn(&str) -> bool>(device: &svd::Device,
 }
 
 fn gen_peripheral_desc(p: &svd::Peripheral, def: &svd::Defaults) -> String {
-    svd2rust::gen_peripheral(p, &def)
+    svd2rust::gen_peripheral(p, def)
         .iter()
         .map(|i| i.to_string())
         .collect::<Vec<_>>()


### PR DESCRIPTION
This PR is like #52 but with an alternative write API.

The generated write API looks like this:

``` rust
#[derive(Clone, Copy)]
#[repr(C)]
pub struct DirW {
    bits: u32,
}

pub struct DirWPin0<'a> {
    register: &'a mut DirW,
}

impl<'a> DirWPin0<'a> {
    pub fn input(self) -> &'a mut DirW {
        const MASK: u32 = 1;
        const OFFSET: u8 = 0u8;
        self.register.bits &= !((MASK as u32) << OFFSET);
        self.register.bits |= 0u32 << OFFSET;
        self.register
    }

    pub fn output(self) -> &'a mut DirW {
        const MASK: u32 = 1;
        const OFFSET: u8 = 0u8;
        self.register.bits &= !((MASK as u32) << OFFSET);
        self.register.bits |= 1u32 << OFFSET;
        self.register
    }
}

impl DirW {
    #[doc = "Bit 0 - Pin 0."]
    pub fn pin0(&mut self) -> DirWPin0 {
        DirWPin0 { register: self }
    }
    
    ..
}
```

Instead of exposing a method that takes an enum to modify a bitfield of a
register (`register.bitfield(Enum::VariantA)`), like in #52, this API exposes a
method that returns a proxy struct whose methods let you pick a value for the
bitfield (`register.bitfield().variant_a()`) *and* this method returns back the
register so you don't lose the chain-ability:
`register.bitfield1().variant_a().bitfield2().variant_b()`. 

[Here's](https://github.com/japaric/nrf51822/pull/5/files#diff-f5c08210e017893c364670505e0738f9) the blinky example from #52 ported to this alternative write API.

cc @brandonedens