### PR TITLE
[WIP] interrupt table generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "either 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "inflections 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "svd-parser 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "svd-parser 0.3.0 (git+https://github.com/japaric/svd?branch=interrupt)",
  "syn 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -72,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "svd-parser"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/japaric/svd?branch=interrupt#9864270ad50c3fa587bbf4f63af321f4f5a0a756"
 dependencies = [
  "xmltree 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -152,7 +152,7 @@ dependencies = [
 "checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
 "checksum quote 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6732e32663c9c271bfc7c1823486b471f18c47a2dbf87c066897b7b51afc83be"
 "checksum strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "67f84c44fbb2f91db7fef94554e6b2ac05909c9c0b0bc23bb98d3a1aebfe7f7c"
-"checksum svd-parser 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "726fd935d2826ae574f18229e985639e0b9465f9d188e136d8f599c78b881ed1"
+"checksum svd-parser 0.3.0 (git+https://github.com/japaric/svd?branch=interrupt)" = "<none>"
 "checksum syn 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "76c2db66dc579998854d84ff0ff4a81cb73e69596764d144ce7cece4d04ce6b5"
 "checksum term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7f5f3f71b0040cecc71af239414c23fd3c73570f5ff54cf50e03cef637f2a0"
 "checksum unicode-segmentation 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c3bc443ded17b11305ffffe6b37e2076f328a5a8cb6aa877b1b98f77699e98b5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ clap = "2.14.0"
 either = "1.0.2"
 inflections = "1.0.0"
 quote = "0.3.3"
-svd-parser = "0.3.0"
+svd-parser = { git = "https://github.com/japaric/svd", branch = "interrupt" }
 syn = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1273,11 +1273,11 @@ pub fn gen_interrupts(peripherals: &[Peripheral]) -> Tokens {
             uses_reserved = true;
             fields.push(quote! {
                 /// Reserved spot in the vector table
-                #name: [Reserved; #n],
+                pub #name: [Reserved; #n],
             });
 
             exprs.push(quote! {
-                #name: [Reserved::Vector; #n],
+                pub #name: [Reserved::Vector; #n],
             });
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1346,6 +1346,7 @@ pub fn gen_interrupts(peripherals: &[Peripheral]) -> Tokens {
         }
 
         unsafe impl Nr for Interrupt {
+            #[inline(always)]
             fn nr(&self) -> u8 {
                 match *self {
                     #(#arms)*

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,11 +34,7 @@ fn main() {
     let d = svd::parse(xml);
     match matches.value_of("peripheral") {
         None => {
-            for peripheral in &d.peripherals {
-                println!("const {}: usize = 0x{:08x};",
-                         peripheral.name,
-                         peripheral.base_address);
-            }
+            println!("{}", svd2rust::gen_interrupts(&d.peripherals));
         }
         Some(pattern) => {
             if let Some(peripheral) = find_peripheral(&d, |n| n == pattern)
@@ -83,13 +79,15 @@ fn merge(p: &svd::Peripheral, bp: &svd::Peripheral) -> svd::Peripheral {
             p.name,
             bp.name);
 
+    let mut interrupts = bp.interrupt.clone();
+    interrupts.extend(p.interrupt.iter().cloned());
     svd::Peripheral {
         name: p.name.clone(),
         base_address: p.base_address,
         derived_from: None,
         group_name: p.group_name.clone().or_else(|| bp.group_name.clone()),
         description: p.description.clone().or_else(|| bp.description.clone()),
-        interrupt: p.interrupt.clone().or_else(|| bp.interrupt.clone()),
+        interrupt: interrupts,
         registers: p.registers.clone().or_else(|| bp.registers.clone()),
     }
 }


### PR DESCRIPTION
this PR adds interrupt table generation. It's quite a hack for now. It doesn't
even have a proper CLI invocation ... I just replaced the default CLI
invocation:

```
$ svd2rust -i $SVD
```

Produces this:

``` rust
/// Interrupt handlers
#[repr(C)]
pub struct Interrupts {
    /// Window Watchdog interrupt
    pub wwdg: Handler,
    /// PVD through EXTI line detection interrupt
    pub pvd: Handler,
    (..)
    /// ADC3 global interrupt
    pub adc3: Handler,
    /// Reserved spot in the vector table ]
    _reserved0: [Reserved; 3],
    (..)
}

/// Interrupt default handlers
pub const DEFAULT_HANDLERS: Interrupts = Interrupts {
    wwdg: exceptions::default_handler,
    pvd: exceptions::default_handler,
    (..)
}

/// Interrupts
pub enum Interrupt {
    /// Window Watchdog interrupt
    Wwdg,
    /// PVD through EXTI line detection interrupt
    Pvd,
    (..)
}

impl Interrupt {
    /// Interrupt number
    pub fn nr(&self) -> u8 {
        match *self {
            Interrupt::Wwdg => 0,
            Interrupt::Pvd => 1,
            (..)
        }
    }
}
```

---

The way to use this generated code is documented in the [`cortex-m-template`].
But to sum it up: Applications have to define an `_INTERRUPTS` symbol; the
linker script will put that symbol in the right place:

[`cortex-m-template`]: https://github.com/japaric/cortex-m-template

```
fn main() {
    ..
}

unsafe extern "C" my_interrupt_handler() {
    ..
}

// Handle the ADC1 interrupt using `my_interrupt_handler`
// All the other interrupts will be handled by `default_handler`
pub static _INTERRUPTS: Interrupts = Interrupts {
    adc1: my_interrupt_handler,
    ..interrupts::DEFAULT_HANDLERS
};
```

Most applications won't use all the interrupts so the `DEFAULT_HANDLERS`
constant can be used to just redirect all the unused interrupts to
`default_handler`.

The `Interrupt` enum is meant to be used with the NVIC peripheral. The `nr`
method returns the "id" of each interrupt.

---

The generated code has a few dependencies:

- `Handler`

``` rust
pub type Handler = unsafe extern "C" fn();
```

This one comes from the [`cortex-m`] crate.

[`cortex-m`]: https://crates.io/crates/cortex-m

- `default_handler`

``` rust
unsafe extern "C" fn default_handler() {
    ..
}
```

This one is defined in [`cortex-m-template`].

- `Reserved`

``` rust
pub enum Reserved {
    Vector = 0,
}
```

Also defined in [`cortex-m-template`].

---

If we want to go forward with this approach to interrupts then are going to have
to move all the above dependencies into a single crate (the cortex-m crate) and
have the generated code depend on that crate.

Thoughts on this approach?
cc @grossws