### PR TITLE
Using C layout for RegisterBlock structs

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -309,6 +309,7 @@ fn register_block(registers: &[Register], defs: &Defaults) -> Result<Tokens> {
 
     Ok(quote! {
         /// Register block
+        #[repr(C)]
         pub struct RegisterBlock {
             #(#fields)*
         }


### PR DESCRIPTION
Rust representation doesn't even guarantee keeping the order, I've found
some registers in the wrong place and this fixed it.