### PR TITLE
Do not emit `mod interrupt` if there aren't any defined

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -219,14 +219,16 @@ pub fn interrupt(peripherals: &[Peripheral], items: &mut Vec<Tokens>) {
         },
     );
 
-    items.push(
-        quote! {
-            /// Interrupts
-            pub mod interrupt {
-                #(#mod_items)*
-            }
-        },
-    );
+    if interrupts.len() > 0 {
+        items.push(
+            quote! {
+                /// Interrupts
+                pub mod interrupt {
+                    #(#mod_items)*
+                }
+            },
+        );
+    }
 }
 
 pub fn peripheral(


### PR DESCRIPTION
Or else the resulting file will not compile.

Fixes #77.