### PR TITLE
If <resetValue> is not present at any level, assume it is zero

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -494,11 +494,8 @@ pub fn register(
 
         let rv = register.reset_value
             .or(defs.reset_value)
-            .map(|rv| util::unsuffixed(u64(rv)))
-            .ok_or_else(|| {
-                            format!("Register {} has no reset value",
-                                    register.name)
-                        })?;
+            .or(Some(0))
+            .map(|rv| util::unsuffixed(u64(rv)));
 
         w_impl_items.push(
             quote! {


### PR DESCRIPTION
CMSIS-SVD specification does not require <resetValue> to be present,
so failing when it isn't is wrong. In general, it seems safe to
assume that it's just zero.

Fixes #75.