### PR TITLE
Add a .reset() method as a short-hand for .write(|w| w)

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -518,6 +518,18 @@ pub fn register(
         );
     }
 
+    if access == Access::ReadWrite {
+        reg_impl_items.push(
+            quote! {
+                /// Writes the reset value to the register
+                #[inline(always)]
+                pub fn reset(&self) {
+                    self.write(|w| w)
+                }
+            }
+        )
+    }
+
     mod_items.push(
         quote! {
             impl super::#name_pc {


### PR DESCRIPTION
This is only done for Access::ReadWrite because writing the reset
value to write-only registers does not seem like it has any potential
use at all.

Fixes #19.