### PR TITLE
Do not reject peripherals without registers

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -274,10 +274,8 @@ pub fn peripheral(
 
     let registers = p.registers
         .as_ref()
-        .ok_or_else(|| {
-                        format!("Peripheral {} has no <registers> fields",
-                                p.name)
-                    })?;
+        .map(|x| x.as_ref())
+        .unwrap_or(&[][..]);
 
     // No `struct RegisterBlock` can be generated
     if registers.is_empty() {


### PR DESCRIPTION
For TM4C, interrupts cannot be automatically, easily, or possibly
at all (since SVD does not define how interrupt sharing should work)
be associated in an 1:n fashion to peripherals.

Since svd2rust does not really care where the interrupts are in SVD,
I simply emit a fake peripheral with the complete list of interrupts
(but no registers at all). This peripheral thence does not show up
in the generated code, except in `mod interrupts`.

The SVD specification permits this behavior (the `<registers>`
element is marked as `0..1` occurrences; nowhere in the text
I could find a requirement that a peripheral have registers;
and it passes schema validation).