### PR TITLE
Fix a possible shift past integer width

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -950,7 +950,7 @@ pub fn fields(
             if let Some(write_constraint) = f.write_constraint {
                 match *write_constraint {
                     WriteConstraint::Range(ref range) => {
-                        if range.min == 0 && range.max == (1 << f.width) - 1 {
+                        if range.min as u64 == 0 && range.max as u64 == (1u64 << f.width) - 1 {
                             // the SVD has acknowledged that it's safe to write
                             // any value that can fit in the bitfield
                             safety = None;


### PR DESCRIPTION
This happens for a write constraint specifying the range 0..2^32-1.