### PR TITLE
Add square brackets [ and ] to BLACKLIST_CHARS

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -11,7 +11,7 @@ use errors::*;
 
 /// List of chars that some vendors use in their peripheral/field names but
 /// that are not valid in Rust ident
-const BLACKLIST_CHARS: &'static [char] = &['(', ')'];
+const BLACKLIST_CHARS: &'static [char] = &['(', ')', '[', ']'];
 
 pub trait ToSanitizedPascalCase {
     fn to_sanitized_pascal_case(&self) -> Cow<str>;


### PR DESCRIPTION
ST use square brackets in some fields where the field has been extended to have more bits elsewhere in the register, so the field ends up with a name like OC2M[3]:

![oc2m3](https://cloud.githubusercontent.com/assets/47219/26685852/2b3f6ff4-46e3-11e7-92ae-976289867ef9.png)

The resulting code is `struct Oc2m[3]R` which of course won't compile. Adding square brackets to the blacklist gives `struct Oc2m3R` instead which works and seems reasonable.