### PR TITLE
Don't add is_VARIANT when VARIANT is 'set' or 'clear' and width is 1

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -949,6 +949,10 @@ pub fn fields(
                         let pc = &v.pc;
                         let sc = &v.sc;
 
+                        if f.width == 1 && (sc == "clear" || sc == "set") {
+                            continue;
+                        }
+
                         let is_variant = if sc.as_ref().starts_with("_") {
                             Ident::new(&*format!("is{}", sc))
                         } else {


### PR DESCRIPTION
If a field enumeratedValues includes variants `set` or `clear`, and the field width is 1, then the generated Rust contains a duplicate `is_set` or `is_clear` method.

I think it's reasonable for an SVD file to have a `Clear` variant, in the verb sense, for clearing an interrupt flag in a Flag Clear Register. It gives you a `clear()` method on the field, rather than `bit(false)`.

This patch skips generating is_VARIANT when this condition is met.