### PR TITLE
Rename bit read/write methods.

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -889,13 +889,13 @@ pub fn fields(
                         enum_items.push(quote! {
                             /// Returns `true` if the bit is clear (0)
                             #[inline(always)]
-                            pub fn is_clear(&self) -> bool {
+                            pub fn is_bit_clear(&self) -> bool {
                                 !self.#bits()
                             }
 
                             /// Returns `true` if the bit is set (1)
                             #[inline(always)]
-                            pub fn is_set(&self) -> bool {
+                            pub fn is_bit_set(&self) -> bool {
                                 self.#bits()
                             }
                         });
@@ -1014,13 +1014,13 @@ pub fn fields(
                     pc_r_impl_items.push(quote! {
                         /// Returns `true` if the bit is clear (0)
                         #[inline(always)]
-                        pub fn is_clear(&self) -> bool {
+                        pub fn is_bit_clear(&self) -> bool {
                             !self.#bits()
                         }
 
                         /// Returns `true` if the bit is set (1)
                         #[inline(always)]
-                        pub fn is_set(&self) -> bool {
+                        pub fn is_bit_set(&self) -> bool {
                             self.#bits()
                         }
                     });
@@ -1246,16 +1246,18 @@ pub fn fields(
                         );
                     }
                 }
-            } else if width == 1 {
+            }
+
+            if width == 1 {
                 proxy_items.push(
                     quote! {
                         /// Sets the field bit
-                        pub fn set(self) -> &'a mut W {
+                        pub fn set_bit(self) -> &'a mut W {
                             self.bit(true)
                         }
 
                         /// Clears the field bit
-                        pub fn clear(self) -> &'a mut W {
+                        pub fn clear_bit(self) -> &'a mut W {
                             self.bit(false)
                         }
                     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -96,6 +96,12 @@ impl ToSanitizedSnakeCase for str {
                     where,
                     while,
                     yield,
+                    bit_set,
+                    bit_clear,
+                    set_bit,
+                    clear_bit,
+                    bit,
+                    bits,
                 }
             }
         }


### PR DESCRIPTION
`set()` -> `set_bit()`
`clear()` -> `clear_bit()`
`is_set()` -> `is_bit_set()`
`is_clear()` -> `is_bit_clear()`

Also adds these names to the list of reserved keywords along with `bit` and `bits`
so that they are suffixed with an underscore if used as a variant name.

Also causes the `set_bit()` and `clear_bit()` methods to be added even if the field has an enumeratedValues.

#99 #92 @whitequark 