### PR TITLE
Rename is_bit_clear to bit_is_clear, is_bit_set to bit_is_set

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -889,13 +889,13 @@ pub fn fields(
                         enum_items.push(quote! {
                             /// Returns `true` if the bit is clear (0)
                             #[inline(always)]
-                            pub fn is_bit_clear(&self) -> bool {
+                            pub fn bit_is_clear(&self) -> bool {
                                 !self.#bits()
                             }
 
                             /// Returns `true` if the bit is set (1)
                             #[inline(always)]
-                            pub fn is_bit_set(&self) -> bool {
+                            pub fn bit_is_set(&self) -> bool {
                                 self.#bits()
                             }
                         });
@@ -1014,13 +1014,13 @@ pub fn fields(
                     pc_r_impl_items.push(quote! {
                         /// Returns `true` if the bit is clear (0)
                         #[inline(always)]
-                        pub fn is_bit_clear(&self) -> bool {
+                        pub fn bit_is_clear(&self) -> bool {
                             !self.#bits()
                         }
 
                         /// Returns `true` if the bit is set (1)
                         #[inline(always)]
-                        pub fn is_bit_set(&self) -> bool {
+                        pub fn bit_is_set(&self) -> bool {
                             self.#bits()
                         }
                     });

--- a/src/util.rs
+++ b/src/util.rs
@@ -96,8 +96,6 @@ impl ToSanitizedSnakeCase for str {
                     where,
                     while,
                     yield,
-                    bit_set,
-                    bit_clear,
                     set_bit,
                     clear_bit,
                     bit,


### PR DESCRIPTION
Ugh, I know we just merged #109 but after using it for a couple of days I think it really should have been `bit_is_set()` rather than `is_bit_set()`. I'm happy with `set_bit()` and `clear_bit()` though, they seem natural:


```rust
usart3.cr3.dmat().set_bit();
while usart3.isr().tc().bit_is_clear() {}

if usart3.isr().ore().bit_is_set() {
    ...
}
```

As an added bonus, this way around we don't have to reserve the `bit_set`/`bit_clear` variant names, because it will no longer clash.

What do you think?