### PR TITLE
[RFC] multiarch support for svd2rust

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -34,6 +34,7 @@ main() {
 
     # test crate
     cargo init --name foo $td
+    echo 'bare-metal = "0.1.0"' >> $td/Cargo.toml
     echo 'cortex-m = { git = "https://github.com/japaric/cortex-m" }' >> $td/Cargo.toml
     echo 'cortex-m-rt = { git = "https://github.com/japaric/cortex-m-rt" }' >> $td/Cargo.toml
     echo 'vcell = "0.1.0"' >> $td/Cargo.toml

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -73,12 +73,12 @@ pub fn device(
     }
 
     items.push(quote! {
-        extern crate mcu;
+        extern crate bare_metal;
         extern crate vcell;
 
         use core::ops::Deref;
 
-        use mcu::Peripheral;
+        use bare_metal::Peripheral;
     });
 
     if let Some(cpu) = d.cpu.as_ref() {
@@ -155,7 +155,7 @@ pub fn interrupt(
     let mut pos = 0;
     let mut mod_items = vec![];
     mod_items.push(quote! {
-            use mcu::Nr;
+            use bare_metal::Nr;
         });
     for interrupt in &interrupts {
         while pos < interrupt.value {


### PR DESCRIPTION
# Background

@pftbest has been doing a great work at getting msp430 support at the
[cortex-m-quickstart] level by porting a bunch of cortex-m-* crates to msp430.
They also have a fork of svd2rust that can generate msp430 device crates from
msp430 SVD files.

[cortex-m-quickstart]: https://github.com/japaric/cortex-m-quickstart

In parallel @ahixon has been working with bare metal Cortex-A processors and
they also want to be able to use svd2rust to generate a device crate for their
Cortex-A processor.

This RFC / PR is about adding multiarch support to svd2rust to support these two
cases.

# How

As @ahixon suggested this RFC proposes moving non Cortex-M bits from the
`cortex-m` crate into a common crate: the [`mcu`] crate. Both the `cortex-m`
crate and the `msp430` crate, its MSP430 counterpart, will re-export the common
code from the `mcu` crate in their APIs. The shared API includes:

[`mcu`]: https://github.com/japaric/mcu

- the `Nr` trait
- the `Peripheral` struct
- the `CriticalSection` struct
- the `Mutex` struct

Additionally svd2rust will be tweaked to generate code that depends on the `mcu`
crate rather than on the `cortex-m` crate where possible.

Finally, a `--target` flag that accepts the values "cortex-m", "msp430" and
"none" will be added to the svd2rust tool. This flag tweaks code generation.
When "msp430" is selected the generated crate will depend on the `msp430` crate
and optionally (`#[cfg(feature = "rt")]`) on the `msp430-rt` crate. The
"cortex-m" value has a similar effect. The "none" flag forces the generated
crate to not depend on any specific architecture crate.

# Unresolved questions

- Is there a better name for the `mcu` crate?

- `--target` or `--arch`?

# Implementation bits

- [cortex-m](https://github.com/japaric/cortex-m/pull/57)
- svd2rust: this PR
- [msp430](https://github.com/pftbest/msp430/pull/1)
- [msp430-rt](https://github.com/pftbest/msp430-rt/pull/1)
- [msp430g2553](https://github.com/pftbest/msp430g2553/pull/1)
- [msp430-quickstart](https://github.com/japaric/msp430-quickstart), a demo

cc @awygle
