### PR TITLE
Implemented new functions to format literals as seperated hex idents

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -916,7 +916,7 @@ pub fn fields(
                 sc: Ident::new(&*sc),
                 mask: util::hex_or_bool((((1 as u64) << width) - 1) as u32, width),
                 name: &f.name,
-                offset: util::hex(f.bit_range.offset),
+                offset: util::unsuffixed(u64::from(f.bit_range.offset)),
                 ty: width.to_ty()?,
                 write_constraint: f.write_constraint.as_ref(),
             })

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,7 @@ use inflections::Inflect;
 use svd::{self, Access, EnumeratedValues, Field, Peripheral, Register,
           Usage};
 use syn::{self, Ident, IntTy, Lit};
+use quote::Tokens;
 
 use errors::*;
 
@@ -277,6 +278,32 @@ pub fn access_of(register: &Register) -> Access {
                 Access::ReadWrite
             },
         )
+}
+
+/// Turns `n` into an unsuffixed separated hex tokens
+pub fn hex(n: u32) -> Tokens {
+    let mut t = Tokens::new();
+    let (h2, h1) = ((n >> 16) & 0xffff, n & 0xffff);
+    t.append(if h2 != 0 {
+        format!("0x{:04x}_{:04x}", h2, h1)
+    } else if h1 & 0xff00 != 0 {
+        format!("0x{:04x}", h1)
+    } else if h1 != 0 {
+        format!("0x{:02x}", h1 & 0xff)
+    } else {
+        String::from("0")
+    });
+    t
+}
+
+pub fn hex_or_bool(n: u32, width: u32) -> Tokens {
+    if width == 1 {
+        let mut t = Tokens::new();
+        t.append(if n == 0 { "false" } else { "true" });
+        t
+    } else {
+        hex(n)
+    }
 }
 
 /// Turns `n` into an unsuffixed literal

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use inflections::Inflect;
 use svd::{self, Access, EnumeratedValues, Field, Peripheral, Register,
           Usage};
-use syn::{self, Ident, IntTy, Lit};
+use syn::{self, Ident};
 use quote::Tokens;
 
 use errors::*;
@@ -280,7 +280,7 @@ pub fn access_of(register: &Register) -> Access {
         )
 }
 
-/// Turns `n` into an unsuffixed separated hex tokens
+/// Turns `n` into an unsuffixed separated hex token
 pub fn hex(n: u32) -> Tokens {
     let mut t = Tokens::new();
     let (h2, h1) = ((n >> 16) & 0xffff, n & 0xffff);
@@ -306,18 +306,18 @@ pub fn hex_or_bool(n: u32, width: u32) -> Tokens {
     }
 }
 
-/// Turns `n` into an unsuffixed literal
-pub fn unsuffixed(n: u64) -> Lit {
-    Lit::Int(n, IntTy::Unsuffixed)
+/// Turns `n` into an unsuffixed token
+pub fn unsuffixed(n: u64) -> Tokens {
+    let mut t = Tokens::new();
+    t.append(format!("{}", n));
+    t
 }
 
-pub fn unsuffixed_or_bool(n: u64, width: u32) -> Lit {
+pub fn unsuffixed_or_bool(n: u64, width: u32) -> Tokens {
     if width == 1 {
-        if n == 0 {
-            Lit::Bool(false)
-        } else {
-            Lit::Bool(true)
-        }
+        let mut t = Tokens::new();
+        t.append(if n == 0 { "false" } else { "true" });
+        t
     } else {
         unsuffixed(n)
     }


### PR DESCRIPTION
The two main reasons behind this change are ensuring that the numbers
(mostly addresses, masks and default values) line up with the datasheet
for easier searching and verification since those are pretty much always
expressed in hexadecimal. The other reason being clippy now complains
about long numeric literals (without seperators) being hard to read -- I
agree.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>