### PR TITLE
hack to make device crates compilable on x86

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -242,11 +242,18 @@ pub fn interrupt(
     match *target {
         Target::CortexM => {
             mod_items.push(quote! {
-                #[cfg(feature = "rt")]
+                #[cfg(all(target_arch = "arm", feature = "rt"))]
                 global_asm!("
                 .thumb_func
                 DH_TRAMPOLINE:
                     b DEFAULT_HANDLER
+                ");
+
+                /// Hack to compile on x86
+                #[cfg(all(target_arch = "x86_64", feature = "rt"))]
+                global_asm!("
+                DH_TRAMPOLINE:
+                    jmp DEFAULT_HANDLER
                 ");
 
                 #[cfg(feature = "rt")]


### PR DESCRIPTION
the global_asm! block, which is behind the "rt" feature, contains ARM specific
assembly that won't compile on x86 so we make that conditional (ARM only) and
provide a different DH_TRAMPOLINE when compiling for x86