### PR TITLE
Assume ARMv6 when `<cpu>` section is missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "svd2rust"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.20.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -243,9 +243,8 @@ pub fn interrupt(
     match *target {
         Target::CortexM => {
             let is_armv6 = match device.cpu {
-                Some(ref cpu) if cpu.name.starts_with("CM0") => true,
-                Some(_) => false,
-                _ => true,  // default to armv6 when the <cpu> section is missing
+                Some(ref cpu) => cpu.name.starts_with("CM0"),
+                None => true,  // default to armv6 when the <cpu> section is missing
             };
 
             if is_armv6 {

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -244,7 +244,8 @@ pub fn interrupt(
         Target::CortexM => {
             let is_armv6 = match device.cpu {
                 Some(ref cpu) if cpu.name.starts_with("CM0") => true,
-                _ => false,
+                Some(_) => false,
+                _ => true,  // default to armv6 when the <cpu> section is missing
             };
 
             if is_armv6 {


### PR DESCRIPTION
This makes the generated crates build in more cases.