### PR TITLE
Change type of `$lty` argument to `ty`

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -359,7 +359,7 @@ pub fn interrupt(
             #[macro_export]
             macro_rules! interrupt {
                 ($NAME:ident, $path:path, locals: {
-                    $($lvar:ident:$lty:ident = $lval:expr;)*
+                    $($lvar:ident:$lty:ty = $lval:expr;)*
                 }) => {
                     #[allow(non_snake_case)]
                     mod $NAME {


### PR DESCRIPTION
`ident` is not sufficient, as it won't allow something like
`::module::Type`.