### PR TITLE
Allow optional 'dim_index' if register name contains [%s]

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -524,7 +524,7 @@ fn register_block(registers: &[Register], defs: &Defaults) -> Result<Tokens> {
                 || {
                     format!("Register {} has no `size` field", register.name)
                 },)?;
-        
+
         match *register {
             Register::Single(ref info) => registers_expanded.push(
                 RegisterBlockField{
@@ -535,14 +535,14 @@ fn register_block(registers: &[Register], defs: &Defaults) -> Result<Tokens> {
                 }
             ),
             Register::Array(ref info, ref array_info) => {
-                let sequential_adresses = register_size == array_info.dim_increment*BITS_PER_BYTE;
+                let sequential_addresses = register_size == array_info.dim_increment*BITS_PER_BYTE;
 
                 let numeral_indexes = array_info.dim_index.clone()
                     .ok_or_else( || format!("Register {} has no `dim_index` field", register.name))?
                     .iter()
                     .all(|element| element.parse::<usize>().is_ok());
-                
-                let sequential_indexes = if numeral_indexes && sequential_adresses {
+
+                let sequential_indexes = if numeral_indexes && sequential_addresses {
                     array_info.dim_index.clone()
                         .unwrap()
                         .iter()
@@ -553,7 +553,7 @@ fn register_block(registers: &[Register], defs: &Defaults) -> Result<Tokens> {
                     false
                 };
 
-                let array_convertible = sequential_indexes && numeral_indexes && sequential_adresses;
+                let array_convertible = sequential_indexes && numeral_indexes && sequential_addresses;
 
                 if array_convertible {
                     registers_expanded.push(
@@ -562,7 +562,7 @@ fn register_block(registers: &[Register], defs: &Defaults) -> Result<Tokens> {
                             description: info.description.clone(),
                             offset: info.address_offset,
                             size: register_size * array_info.dim,
-                        });                                    
+                        });
                 } else {
                     let mut field_num = 0;
                     for field in util::expand_svd_register(register).iter() {
@@ -613,16 +613,16 @@ fn register_block(registers: &[Register], defs: &Defaults) -> Result<Tokens> {
             util::respace(&register.description),
         )
             [..];
-        
+
         fields.append(
             quote! {
                 #[doc = #comment]
             }
         );
-        
+
         register.field.to_tokens(&mut fields);
         Ident::new(",").to_tokens(&mut fields);
-        
+
         offset = register.offset + register.size/BITS_PER_BYTE;
     }
 


### PR DESCRIPTION
Based on SVD spec if the register name contains '[%s]' in its name then the dim_index field is not required.

I think this is a fix for that situation.

This fixes #150 and should then be able to close #146 as i am able to successfully generate after applying these changes.