### PR TITLE
Generate interrupt dispatch code.

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -200,7 +200,8 @@ pub fn interrupt(
     let mut interrupts = interrupts.into_iter().map(|(_, v)| v).collect::<Vec<_>>();
     interrupts.sort_by_key(|i| i.value);
 
-    let mut arms = vec![];
+    let mut nr_arms = vec![];
+    let mut from_arms = vec![];
     let mut elements = vec![];
     let mut names = vec![];
     let mut variants = vec![];
@@ -236,8 +237,12 @@ pub fn interrupt(
             #name_uc,
         });
 
-        arms.push(quote! {
+        nr_arms.push(quote! {
             Interrupt::#name_uc => #value,
+        });
+
+        from_arms.push(quote! {
+            #value => Ok(Interrupt::#name_uc),
         });
 
         elements.push(quote!(Some(#name_uc)));
@@ -354,6 +359,7 @@ pub fn interrupt(
 
     mod_items.push(quote! {
         /// Enumeration of all the interrupts
+        #[derive(Debug)]
         pub enum Interrupt {
             #(#variants)*
         }
@@ -362,7 +368,19 @@ pub fn interrupt(
             #[inline]
             fn nr(&self) -> u8 {
                 match *self {
-                    #(#arms)*
+                    #(#nr_arms)*
+                }
+            }
+        }
+
+        impl TryFrom<u8> for Interrupt {
+            type Error = TryFromIntError;
+
+            #[inline]
+            fn try_from(value: u8) -> Result<Self, Self::Error> {
+                match value {
+                    #(#from_arms)*
+                    _ => Err(),
                 }
             }
         }


### PR DESCRIPTION
Useful for architectures that prefer or mandate dispatching interrupts in
software. Adds #[derive(Debug)] for printing readable interrupt names.