### PR TITLE
Peripherals as scoped singletons

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,7 +1,0 @@
-array_layout = "Block"
-fn_args_layout = "Block"
-fn_call_style = "Block"
-generics_indent = "Block"
-max_width = 80
-where_style = "Rfc"
-write_mode = "overwrite"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
       os: osx
 
 install:
-  - sh ci/install.sh
+  - bash ci/install.sh
 
 script:
   - bash ci/script.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = [
 license = "MIT OR Apache-2.0"
 name = "svd2rust"
 repository = "https://github.com/japaric/svd2rust"
-version = "0.11.4"
+version = "0.12.0"
 
 [[bin]]
 doc = false

--- a/build.rs
+++ b/build.rs
@@ -33,38 +33,21 @@ fn commit_info() -> String {
 }
 
 fn commit_hash() -> Result<String, IgnoredError> {
-    Ok(
+    Ok(try!(String::from_utf8(
         try!(
-            String::from_utf8(
-                try!(
-                    Command::new("git")
-                        .args(&["rev-parse", "--short", "HEAD"])
-                        .output()
-                )
-                        .stdout,
-            )
-        ),
-    )
+            Command::new("git")
+                .args(&["rev-parse", "--short", "HEAD"])
+                .output()
+        ).stdout,
+    )))
 }
 
 fn commit_date() -> Result<String, IgnoredError> {
-    Ok(
+    Ok(try!(String::from_utf8(
         try!(
-            String::from_utf8(
-                try!(
-                    Command::new("git")
-                        .args(
-                            &[
-                                "log",
-                                "-1",
-                                "--date=short",
-                                "--pretty=format:%cd",
-                            ],
-                        )
-                        .output()
-                )
-                        .stdout,
-            )
-        ),
-    )
+            Command::new("git")
+                .args(&["log", "-1", "--date=short", "--pretty=format:%cd"])
+                .output()
+        ).stdout,
+    )))
 }

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,4 +1,4 @@
-set -ex
+set -euxo pipefail
 
 main() {
     local sort=

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -19,7 +19,7 @@ main() {
            --git japaric/cross \
            --tag $tag
 
-    if [ ! -z $VENDOR ]; then
+    if [ ! -z ${VENDOR-} ]; then
         curl -LSfs https://japaric.github.io/trust/install.sh | \
             sh -s -- \
                --crate rustfmt \

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,5 +1,4 @@
-set -ex
-set -o pipefail
+set -euxo pipefail
 
 test_svd() {
     (
@@ -15,7 +14,7 @@ test_svd() {
 }
 
 main() {
-    cross build --target $TARGET
+    cross check --target $TARGET
 
     if [ -z $VENDOR ]; then
         return
@@ -35,7 +34,7 @@ main() {
     # test crate
     cargo init --name foo $td
     echo 'bare-metal = "0.1.0"' >> $td/Cargo.toml
-    echo 'cortex-m = "0.3.0"' >> $td/Cargo.toml
+    echo 'cortex-m = { git = "https://github.com/japaric/cortex-m" }' >> $td/Cargo.toml
     echo 'cortex-m-rt = "0.3.0"' >> $td/Cargo.toml
     echo 'vcell = "0.1.0"' >> $td/Cargo.toml
 
@@ -609,6 +608,6 @@ main() {
     rm -rf $td
 }
 
-if [ -z $TRAVIS_TAG ]; then
+if [ -z ${TRAVIS_TAG-} ]; then
     main
 fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -16,7 +16,7 @@ test_svd() {
 main() {
     cross check --target $TARGET
 
-    if [ -z $VENDOR ]; then
+    if [ -z ${VENDOR-} ]; then
         return
     fi
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -167,7 +167,7 @@ pub fn device(d: &Device, target: &Target, items: &mut Vec<Tokens>) -> Result<()
                 })
             }
 
-            #[doc(hidden)]
+            /// Unchecked version of `Peripherals::take`
             pub unsafe fn steal() -> Self {
                 debug_assert!(!DEVICE_PERIPHERALS);
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -157,6 +157,7 @@ pub fn device(d: &Device, target: &Target, items: &mut Vec<Tokens>) -> Result<()
 
         impl Peripherals {
             /// Returns all the peripherals *once*
+            #[inline(always)]
             pub fn take() -> Option<Self> {
                 cortex_m::interrupt::free(|_| {
                     if unsafe { DEVICE_PERIPHERALS } {

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,10 +107,7 @@ fn main() {
         if let Some(backtrace) = e.backtrace() {
             writeln!(stderr, "backtrace: {:?}", backtrace).ok();
         } else {
-            writeln!(
-                stderr,
-                "note: run with `RUST_BACKTRACE=1` for a backtrace"
-            ).ok();
+            writeln!(stderr, "note: run with `RUST_BACKTRACE=1` for a backtrace").ok();
         }
 
         process::exit(1);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,7 @@
 use std::borrow::Cow;
 
 use inflections::Inflect;
-use svd::{self, Access, EnumeratedValues, Field, Peripheral, Register,
-          Usage};
+use svd::{self, Access, EnumeratedValues, Field, Peripheral, Register, Usage};
 use syn::{self, Ident};
 use quote::Tokens;
 
@@ -141,19 +140,24 @@ pub fn respace(s: &str) -> String {
 /// a list of syn::Field where the register arrays have been expanded.
 pub fn expand_svd_register(register: &Register) -> Vec<syn::Field> {
     let name_to_ty = |name: &String| -> syn::Ty {
-        syn::Ty::Path(None, syn::Path{
-            global: false,
-            segments: vec![syn::PathSegment{
-                ident: Ident::new(name.to_sanitized_upper_case()),
-                parameters: syn::PathParameters::none(),
-            }],
-        })
+        syn::Ty::Path(
+            None,
+            syn::Path {
+                global: false,
+                segments: vec![
+                    syn::PathSegment {
+                        ident: Ident::new(name.to_sanitized_upper_case()),
+                        parameters: syn::PathParameters::none(),
+                    },
+                ],
+            },
+        )
     };
 
     let mut out = vec![];
 
     match *register {
-        Register::Single(ref _info) => out.push( convert_svd_register(register) ),
+        Register::Single(ref _info) => out.push(convert_svd_register(register)),
         Register::Array(ref info, ref array_info) => {
             let has_brackets = info.name.contains("[%s]");
 
@@ -161,65 +165,64 @@ pub fn expand_svd_register(register: &Register) -> Vec<syn::Field> {
                 .dim_index
                 .as_ref()
                 .map(|v| Cow::from(&**v))
-                .unwrap_or_else(
-                    || {
-                        Cow::from(
-                            (0..array_info.dim)
-                                .map(|i| i.to_string())
-                                .collect::<Vec<_>>(),
-                        )
-                    },
-                );
-            
+                .unwrap_or_else(|| {
+                    Cow::from(
+                        (0..array_info.dim)
+                            .map(|i| i.to_string())
+                            .collect::<Vec<_>>(),
+                    )
+                });
+
             for (idx, _i) in indices.iter().zip(0..) {
                 let name = if has_brackets {
                     info.name.replace("[%s]", format!("{}", idx).as_str())
                 } else {
                     info.name.replace("%s", format!("{}", idx).as_str())
                 };
-                
+
                 let ty_name = if has_brackets {
                     info.name.replace("[%s]", "")
                 } else {
                     info.name.replace("%s", "")
                 };
-                    
+
                 let ident = Ident::new(name.to_sanitized_snake_case());
                 let ty = name_to_ty(&ty_name);
 
-                out.push(
-                    syn::Field{
-                        ident: Some(ident),
-                        vis: syn::Visibility::Public,
-                        attrs: vec![],
-                        ty: ty,
-                    }
-                );
+                out.push(syn::Field {
+                    ident: Some(ident),
+                    vis: syn::Visibility::Public,
+                    attrs: vec![],
+                    ty: ty,
+                });
             }
-        },
+        }
     }
     out
 }
 
 pub fn convert_svd_register(register: &svd::Register) -> syn::Field {
     let name_to_ty = |name: &String| -> syn::Ty {
-        syn::Ty::Path(None, syn::Path{
-            global: false,
-            segments: vec![syn::PathSegment{
-                ident: Ident::new(name.to_sanitized_upper_case()),
-                parameters: syn::PathParameters::none(),
-            }],
-        })
+        syn::Ty::Path(
+            None,
+            syn::Path {
+                global: false,
+                segments: vec![
+                    syn::PathSegment {
+                        ident: Ident::new(name.to_sanitized_upper_case()),
+                        parameters: syn::PathParameters::none(),
+                    },
+                ],
+            },
+        )
     };
-    
+
     match *register {
-        Register::Single(ref info) => {
-            syn::Field{
-                ident: Some(Ident::new(info.name.to_sanitized_snake_case())),
-                vis: syn::Visibility::Public,
-                attrs: vec![],
-                ty: name_to_ty(&info.name),
-            }
+        Register::Single(ref info) => syn::Field {
+            ident: Some(Ident::new(info.name.to_sanitized_snake_case())),
+            vis: syn::Visibility::Public,
+            attrs: vec![],
+            ty: name_to_ty(&info.name),
         },
         Register::Array(ref info, ref array_info) => {
             let has_brackets = info.name.contains("[%s]");
@@ -229,55 +232,49 @@ pub fn convert_svd_register(register: &svd::Register) -> syn::Field {
             } else {
                 info.name.replace("%s", "")
             };
-            
+
             let ident = Ident::new(name.to_sanitized_snake_case());
-            
+
             let ty = syn::Ty::Array(
                 Box::new(name_to_ty(&name)),
                 syn::ConstExpr::Lit(syn::Lit::Int(array_info.dim as u64, syn::IntTy::Unsuffixed)),
             );
 
-            syn::Field{
+            syn::Field {
                 ident: Some(ident),
                 vis: syn::Visibility::Public,
                 attrs: vec![],
                 ty: ty,
             }
-        },
+        }
     }
 }
 
 pub fn name_of(register: &Register) -> Cow<str> {
     match *register {
         Register::Single(ref info) => Cow::from(&*info.name),
-        Register::Array(ref info, _) => {
-            if info.name.contains("[%s]") {
-                info.name.replace("[%s]", "").into()
-            } else {
-                info.name.replace("%s", "").into()
-            }
-        }
+        Register::Array(ref info, _) => if info.name.contains("[%s]") {
+            info.name.replace("[%s]", "").into()
+        } else {
+            info.name.replace("%s", "").into()
+        },
     }
 }
 
 pub fn access_of(register: &Register) -> Access {
     register
         .access
-        .unwrap_or_else(
-            || if let Some(ref fields) = register.fields {
-                if fields.iter().all(|f| f.access == Some(Access::ReadOnly)) {
-                    Access::ReadOnly
-                } else if fields
-                              .iter()
-                              .all(|f| f.access == Some(Access::WriteOnly),) {
-                    Access::WriteOnly
-                } else {
-                    Access::ReadWrite
-                }
+        .unwrap_or_else(|| if let Some(ref fields) = register.fields {
+            if fields.iter().all(|f| f.access == Some(Access::ReadOnly)) {
+                Access::ReadOnly
+            } else if fields.iter().all(|f| f.access == Some(Access::WriteOnly)) {
+                Access::WriteOnly
             } else {
                 Access::ReadWrite
-            },
-        )
+            }
+        } else {
+            Access::ReadWrite
+        })
 }
 
 /// Turns `n` into an unsuffixed separated hex token
@@ -330,8 +327,7 @@ pub struct Base<'a> {
     pub field: &'a str,
 }
 
-pub fn lookup<'a>
-    (
+pub fn lookup<'a>(
     evs: &'a [EnumeratedValues],
     fields: &'a [Field],
     register: &'a Register,
@@ -341,42 +337,38 @@ pub fn lookup<'a>
     usage: Usage,
 ) -> Result<Option<(&'a EnumeratedValues, Option<Base<'a>>)>> {
     let evs = evs.iter()
-        .map(
-            |evs| if let Some(ref base) = evs.derived_from {
-                let mut parts = base.split('.');
+        .map(|evs| if let Some(ref base) = evs.derived_from {
+            let mut parts = base.split('.');
 
-                match (parts.next(), parts.next(), parts.next(), parts.next()) {
-                    (Some(base_peripheral), Some(base_register), Some(base_field), Some(base_evs)) => {
-                        lookup_in_peripherals(
-                            base_peripheral,
-                            base_register,
-                            base_field,
-                            base_evs,
-                            all_peripherals,
-                        )
-                    }
-                    (Some(base_register), Some(base_field), Some(base_evs), None) => {
-                        lookup_in_peripheral(
-                            None,
-                            base_register,
-                            base_field,
-                            base_evs,
-                            all_registers,
-                            peripheral,
-                        )
-                    }
-                    (Some(base_field), Some(base_evs), None, None) => {
-                        lookup_in_fields(base_evs, base_field, fields, register)
-                    }
-                    (Some(base_evs), None, None, None) => {
-                        lookup_in_register(base_evs, register)
-                    }
-                    _ => unreachable!(),
+            match (parts.next(), parts.next(), parts.next(), parts.next()) {
+                (Some(base_peripheral), Some(base_register), Some(base_field), Some(base_evs)) => {
+                    lookup_in_peripherals(
+                        base_peripheral,
+                        base_register,
+                        base_field,
+                        base_evs,
+                        all_peripherals,
+                    )
                 }
-            } else {
-                Ok((evs, None))
-            },
-        )
+                (Some(base_register), Some(base_field), Some(base_evs), None) => {
+                    lookup_in_peripheral(
+                        None,
+                        base_register,
+                        base_field,
+                        base_evs,
+                        all_registers,
+                        peripheral,
+                    )
+                }
+                (Some(base_field), Some(base_evs), None, None) => {
+                    lookup_in_fields(base_evs, base_field, fields, register)
+                }
+                (Some(base_evs), None, None, None) => lookup_in_register(base_evs, register),
+                _ => unreachable!(),
+            }
+        } else {
+            Ok((evs, None))
+        })
         .collect::<Result<Vec<_>>>()?;
 
     for &(ref evs, ref base) in evs.iter() {
@@ -397,18 +389,15 @@ fn lookup_in_fields<'f>(
     if let Some(base_field) = fields.iter().find(|f| f.name == base_field) {
         return lookup_in_field(base_evs, None, None, base_field);
     } else {
-        Err(
-            format!(
-                "Field {} not found in register {}",
-                base_field,
-                register.name
-            ),
-        )?
+        Err(format!(
+            "Field {} not found in register {}",
+            base_field,
+            register.name
+        ))?
     }
 }
 
-fn lookup_in_peripheral<'p>
-    (
+fn lookup_in_peripheral<'p>(
     base_peripheral: Option<&'p str>,
     base_register: &'p str,
     base_field: &str,
@@ -416,36 +405,29 @@ fn lookup_in_peripheral<'p>
     all_registers: &'p [Register],
     peripheral: &'p Peripheral,
 ) -> Result<(&'p EnumeratedValues, Option<Base<'p>>)> {
-    if let Some(register) = all_registers.iter().find(
-        |r| {
-            r.name == base_register
-        },
-    ) {
+    if let Some(register) = all_registers.iter().find(|r| r.name == base_register) {
         if let Some(field) = register
-               .fields
-               .as_ref()
-               .map(|fs| &**fs)
-               .unwrap_or(&[])
-               .iter()
-               .find(|f| f.name == base_field) {
+            .fields
+            .as_ref()
+            .map(|fs| &**fs)
+            .unwrap_or(&[])
+            .iter()
+            .find(|f| f.name == base_field)
+        {
             lookup_in_field(base_evs, Some(base_register), base_peripheral, field)
         } else {
-            Err(
-                format!(
-                    "No field {} in register {}",
-                    base_field,
-                    register.name
-                ),
-            )?
+            Err(format!(
+                "No field {} in register {}",
+                base_field,
+                register.name
+            ))?
         }
     } else {
-        Err(
-            format!(
-                "No register {} in peripheral {}",
-                base_register,
-                peripheral.name
-            ),
-        )?
+        Err(format!(
+            "No register {} in peripheral {}",
+            base_register,
+            peripheral.name
+        ))?
     }
 }
 
@@ -458,89 +440,80 @@ fn lookup_in_field<'f>(
     for evs in &field.enumerated_values {
         if evs.name.as_ref().map(|s| &**s) == Some(base_evs) {
             return Ok(
-                ((evs,
-                  Some(
-                    Base {
+                ((
+                    evs,
+                    Some(Base {
                         field: &field.name,
                         register: base_register,
                         peripheral: base_peripheral,
-                    },
-                ))),
+                    }),
+                )),
             );
         }
     }
 
-    Err(format!("No EnumeratedValues {} in field {}", base_evs, field.name),)?
+    Err(format!(
+        "No EnumeratedValues {} in field {}",
+        base_evs,
+        field.name
+    ))?
 }
 
-fn lookup_in_register<'r>
-    (
+fn lookup_in_register<'r>(
     base_evs: &str,
     register: &'r Register,
 ) -> Result<(&'r EnumeratedValues, Option<Base<'r>>)> {
     let mut matches = vec![];
 
     for f in register.fields.as_ref().map(|v| &**v).unwrap_or(&[]) {
-        if let Some(evs) =
-            f.enumerated_values
-                .iter()
-                .find(|evs| evs.name.as_ref().map(|s| &**s) == Some(base_evs)) {
+        if let Some(evs) = f.enumerated_values
+            .iter()
+            .find(|evs| evs.name.as_ref().map(|s| &**s) == Some(base_evs))
+        {
             matches.push((evs, &f.name))
         }
     }
 
     match matches.first() {
-        None => {
-            Err(
-                format!(
-                    "EnumeratedValues {} not found in register {}",
-                    base_evs,
-                    register.name
-                ),
-            )?
-        }
-        Some(&(evs, field)) => {
-            if matches.len() == 1 {
-                return Ok(
-                    (evs,
-                     Some(
-                        Base {
-                            field: field,
-                            register: None,
-                            peripheral: None
-                        },
-                    )),
-                );
-            } else {
-                let fields = matches
-                    .iter()
-                    .map(|&(ref f, _)| &f.name)
-                    .collect::<Vec<_>>();
-                Err(
-                    format!(
-                        "Fields {:?} have an \
-                                             enumeratedValues named {}",
-                        fields,
-                        base_evs
-                    ),
-                )?
-            }
-        }
+        None => Err(format!(
+            "EnumeratedValues {} not found in register {}",
+            base_evs,
+            register.name
+        ))?,
+        Some(&(evs, field)) => if matches.len() == 1 {
+            return Ok((
+                evs,
+                Some(Base {
+                    field: field,
+                    register: None,
+                    peripheral: None,
+                }),
+            ));
+        } else {
+            let fields = matches
+                .iter()
+                .map(|&(ref f, _)| &f.name)
+                .collect::<Vec<_>>();
+            Err(format!(
+                "Fields {:?} have an \
+                 enumeratedValues named {}",
+                fields,
+                base_evs
+            ))?
+        },
     }
 }
 
-fn lookup_in_peripherals<'p>
-(
+fn lookup_in_peripherals<'p>(
     base_peripheral: &'p str,
     base_register: &'p str,
     base_field: &str,
     base_evs: &str,
     all_peripherals: &'p [Peripheral],
 ) -> Result<(&'p EnumeratedValues, Option<Base<'p>>)> {
-    if let Some(peripheral) = all_peripherals
-        .iter()
-        .find(|p| { p.name == base_peripheral }) {
-        let all_registers = peripheral.registers
+    if let Some(peripheral) = all_peripherals.iter().find(|p| p.name == base_peripheral) {
+        let all_registers = peripheral
+            .registers
             .as_ref()
             .map(|x| x.as_ref())
             .unwrap_or(&[][..]);
@@ -550,15 +523,10 @@ fn lookup_in_peripherals<'p>
             base_field,
             base_evs,
             all_registers,
-            peripheral
+            peripheral,
         )
     } else {
-        Err(
-            format!(
-                "No peripheral {}",
-                base_peripheral
-            ),
-        )?
+        Err(format!("No peripheral {}", base_peripheral))?
     }
 }
 
@@ -570,40 +538,28 @@ pub trait U32Ext {
 
 impl U32Ext for u32 {
     fn to_ty(&self) -> Result<Ident> {
-        Ok(
-            match *self {
-                1 => Ident::new("bool"),
-                2...8 => Ident::new("u8"),
-                9...16 => Ident::new("u16"),
-                17...32 => Ident::new("u32"),
-                _ => {
-                    Err(
-                        format!(
-                            "can't convert {} bits into a Rust integral type",
-                            *self
-                        ),
-                    )?
-                }
-            },
-        )
+        Ok(match *self {
+            1 => Ident::new("bool"),
+            2...8 => Ident::new("u8"),
+            9...16 => Ident::new("u16"),
+            17...32 => Ident::new("u32"),
+            _ => Err(format!(
+                "can't convert {} bits into a Rust integral type",
+                *self
+            ))?,
+        })
     }
 
     fn to_ty_width(&self) -> Result<u32> {
-        Ok(
-            match *self {
-                1 => 1,
-                2...8 => 8,
-                9...16 => 16,
-                17...32 => 32,
-                _ => {
-                    Err(
-                        format!(
-                            "can't convert {} bits into a Rust integral type width",
-                            *self
-                        ),
-                    )?
-                }
-            }
-        )
+        Ok(match *self {
+            1 => 1,
+            2...8 => 8,
+            9...16 => 16,
+            17...32 => 32,
+            _ => Err(format!(
+                "can't convert {} bits into a Rust integral type width",
+                *self
+            ))?,
+        })
     }
 }


### PR DESCRIPTION
See this RFC for details: japaric/svd2rust#157

With this change device crates will need to depend on a version of the cortex-m crate that includes japaric/cortex-m#65

### TODO

- [x] accept the RFC
- [ ] ~~Check that non cortex-m targets still work~~ postponed
- [x] decide on better names for `Peripherals::{all,_all}`