### PR TITLE
Add missing unsafe qualifier on 1-bit enumerated fields

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1428,12 +1428,12 @@ pub fn fields(
             if width == 1 {
                 proxy_items.push(quote! {
                     /// Sets the field bit
-                    pub fn set_bit(self) -> &'a mut W {
+                    pub #unsafety fn set_bit(self) -> &'a mut W {
                         self.bit(true)
                     }
 
                     /// Clears the field bit
-                    pub fn clear_bit(self) -> &'a mut W {
+                    pub #unsafety fn clear_bit(self) -> &'a mut W {
                         self.bit(false)
                     }
                 });


### PR DESCRIPTION
E.g. this from tm4c123x.svd generated by dslite2svd:

```
  <field>
    <name>VREF</name>
    <description>Voltage Reference Select</description>
    <lsb>0</lsb>
    <msb>0</msb>
    <access>read-write</access>
    <writeConstraint>
      <useEnumeratedValues>true</useEnumeratedValues>
    </writeConstraint>
    <enumeratedValues>
      <enumeratedValue>
        <name>INTERNAL</name>
        <description>VDDA and GNDA are the voltage references</description>
        <value>0x0</value>
      </enumeratedValue>
    </enumeratedValues>
  </field>
```