### PR TITLE
Emit unions for overlapping/overloaded registers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+[._]*.sw[a-p]
 *.org
 *.rs.bk
 *.svd

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -43,6 +43,7 @@ pub fn render(d: &Device, target: &Target) -> Result<Vec<Tokens>> {
         #![allow(non_camel_case_types)]
         #![feature(const_fn)]
         #![feature(try_from)]
+        #![feature(untagged_unions)]
         #![no_std]
     });
 

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -9,7 +9,7 @@ use Target;
 use generate::{interrupt, peripheral};
 
 /// Whole device generation
-pub fn render(d: &Device, target: &Target) -> Result<Vec<Tokens>> {
+pub fn render(d: &Device, target: &Target, nightly: bool) -> Result<Vec<Tokens>> {
     let mut out = vec![];
 
     let doc = format!(
@@ -43,9 +43,14 @@ pub fn render(d: &Device, target: &Target) -> Result<Vec<Tokens>> {
         #![allow(non_camel_case_types)]
         #![feature(const_fn)]
         #![feature(try_from)]
-        #![feature(untagged_unions)]
         #![no_std]
     });
+
+    if nightly {
+        out.push(quote! {
+            #![feature(untagged_unions)]
+        });
+    }
 
     match *target {
         Target::CortexM => {
@@ -128,7 +133,7 @@ pub fn render(d: &Device, target: &Target) -> Result<Vec<Tokens>> {
         }
 
 
-        out.extend(peripheral::render(p, &d.peripherals, &d.defaults)?);
+        out.extend(peripheral::render(p, &d.peripherals, &d.defaults, nightly)?);
 
         if p.registers
             .as_ref()

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -7,7 +7,7 @@ use svd::{Cluster, ClusterInfo, Defaults, Peripheral, Register};
 use syn::{self, Ident};
 
 use errors::*;
-use util::{self, ToSanitizedSnakeCase, ToSanitizedUpperCase, BITS_PER_BYTE};
+use util::{self, ToSanitizedPascalCase, ToSanitizedSnakeCase, ToSanitizedUpperCase, BITS_PER_BYTE};
 
 use generate::register;
 
@@ -316,10 +316,10 @@ fn register_or_cluster_block(
         if region.fields.len() > 1 && !block_is_union {
             let (type_name, name) = match region.shortest_ident() {
                 Some(prefix) => {
-                    (Ident::new(format!("{}Union", prefix.to_sanitized_upper_case())),
+                    (Ident::new(format!("{}Union", prefix.to_sanitized_pascal_case())),
                     Ident::new(prefix))
                 }
-                // If we can't find a name, fall back to theregion index as a
+                // If we can't find a name, fall back to the region index as a
                 // unique-within-this-block identifier counter.
                 None => {
                    let ident = Ident::new(format!("U{}", i));

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -297,6 +297,12 @@ fn register_or_cluster_block(
         let mut region_fields = Tokens::new();
 
         for reg_block_field in &region.fields {
+            if reg_block_field.offset != region.offset {
+                eprintln!("WARNING: field {:?} has different offset {} than its union container {}",
+                    reg_block_field.field.ident,
+                    reg_block_field.offset,
+                    region.offset);
+            }
             let comment = &format!(
                 "0x{:02x} - {}",
                 reg_block_field.offset,

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,11 @@ fn run() -> Result<()> {
                 .takes_value(true)
                 .value_name("ARCH"),
         )
+        .arg(
+            Arg::with_name("nightly_features")
+                .long("nightly")
+                .help("Enable features only available to nightly rustc")
+        )
         .version(concat!(
             env!("CARGO_PKG_VERSION"),
             include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt"))
@@ -91,7 +96,9 @@ fn run() -> Result<()> {
 
     let device = svd::parse(xml);
 
-    let items = generate::device::render(&device, &target)?;
+    let nightly = matches.is_present("nightly_features");
+
+    let items = generate::device::render(&device, &target, nightly)?;
 
     println!(
         "{}",


### PR DESCRIPTION
I want to get a complete working build for ATSAMD21 (https://github.com/rust-lang-nursery/embedded-wg/issues/61) so I'm taking a stab at that.

* Introduced a `FieldRegion` helper to reason about overlapping regions
* If overlaps are detected, a `union` container is emitted
* If the only item in a `RegisterBlock` is a union, that `RegisterBlock` is emitted as a union
* Otherwise: we generate a name for the union field by either taking the shortest common prefix of the union's alternates or the shortest register name (depending on type name conflicts). If that doesn't work just pick an artificial name like `u1`.
* If the starting address offset of elements in a union are not all the same, we don't have a way to emit padding for them today.  We will emit a warning (and bad code) in that case (example below).  The one example of this I see in ATSAMD21 is due to missing `derivedFrom` support for registers; we're currently generating bad code for these anyway.  I have resolved in another branch that I'll turn into a PR once this one is landed.

```
WARNING: field Some(Ident("pmux1_1")) has different offset 177 than its union container 176
WARNING: field Some(Ident("pmux1_2")) has different offset 178 than its union container 176
```

Examples:

```
#[doc = "Real-Time Counter"]
pub mod rtc {
    #[doc = r" Register block"]
    #[repr(C)]
    pub union RegisterBlock {
        #[doc = "0x00 - Clock/Calendar with Alarm"]
        pub mode2: MODE2,
        #[doc = "0x00 - 16-bit Counter with Two 16-bit Compares"]
        pub mode1: MODE1,
        #[doc = "0x00 - 32-bit Counter with Single 32-bit Compare"]
        pub mode0: MODE0,
    }
```

```
    #[doc = r" Register block"]
    #[repr(C)]
    pub struct USART {
        #[doc = "0x00 - USART Control A"]
        pub ctrla: self::usart::CTRLA,
        #[doc = "0x04 - USART Control B"]
        pub ctrlb: self::usart::CTRLB,
        _reserved2: [u8; 4usize],
        #[doc = "USART Baud Rate"]
        pub baud: baud_union,
      ...
    }
    #[doc = "USART Baud Rate"]
    #[repr(C)]
    pub union baud_union {
        #[doc = "0x0c - USART Baud Rate"]
        pub baud_usartfp_mode: self::usart::BAUD_USARTFP_MODE,
        #[doc = "0x0c - USART Baud Rate"]
        pub baud_fracfp_mode: self::usart::BAUD_FRACFP_MODE,
        #[doc = "0x0c - USART Baud Rate"]
        pub baud_frac_mode: self::usart::BAUD_FRAC_MODE,
        #[doc = "0x0c - USART Baud Rate"]
        pub baud: self::usart::BAUD,
    }
```

Refs: https://github.com/japaric/svd2rust/issues/191 
https://github.com/japaric/svd2rust/issues/16

