### PR TITLE
Ignore UTF-8 BOM in SVD files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn run() -> Result<()> {
         .read_to_string(xml)
         .chain_err(|| "couldn't read the SVD file")?;
 
-    let device = svd::parse(xml);
+    let device = svd::parse(util::trim_utf8_bom(xml));
 
     let items = generate::device::render(&device, &target)?;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -261,3 +261,12 @@ pub fn only_registers(ercs: &[Either<Register, Cluster>]) -> Vec<&Register> {
         .collect();
     registers
 }
+
+/// Return the &str trimed BOM if it contains UTF-8 BOM.
+pub fn trim_utf8_bom(s: &str) -> &str {
+    if s.len() > 2 && s.as_bytes().starts_with(&[0xefu8, 0xbbu8, 0xbfu8]) {
+        &s[3..]
+    } else {
+        s
+    }
+}


### PR DESCRIPTION
I tested using nrf52.svd that contains UTF-8 BOM in nRF5 SDK.
The SDK zip file is [here](https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.0.0_a53641a.zip).

svd2rust failed.
```sh
$ svd2rust -i nrf52.svd
thread 'main' panicked at '/home/ryo/.cargo/registry/src/github.com-1ecc6299db9ec823/svd-parser-0.6.0/src/lib.rs:89 Element::parse(svd.as_bytes()): MalformedXml(Error { pos: 1:1, kind: Syntax("Unexpected characters outside the root element: \u{feff}") })', libcore/result.rs:945:5
```

This PR is to support SVD files contains UTF-8 BOM. (Ignore BOM)