### PR TITLE
Expose internals to lib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,6 +410,25 @@
 
 // NOTE This file is for documentation only
 
+#![recursion_limit = "128"]
+
+extern crate cast;
+extern crate either;
+#[macro_use]
+extern crate error_chain;
+extern crate inflections;
+#[macro_use]
+pub extern crate quote;
+pub extern crate svd_parser as svd;
+extern crate syn;
+
+mod errors;
+pub mod generate;
+mod util;
+pub mod target;
+
+use target::Target;
+
 /// Assigns a handler to an interrupt
 ///
 /// This macro takes two arguments: the name of an interrupt and the path to the

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ extern crate syn;
 mod errors;
 mod generate;
 mod util;
+mod target;
 
 use std::fs::File;
 use std::{io, process};
@@ -21,14 +22,7 @@ use std::{io, process};
 use clap::{App, Arg};
 
 use errors::*;
-
-#[derive(Clone, Copy, PartialEq)]
-pub enum Target {
-    CortexM,
-    Msp430,
-    RISCV,
-    None,
-}
+use target::Target;
 
 impl Target {
     fn parse(s: &str) -> Result<Self> {

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,0 +1,7 @@
+#[derive(Clone, Copy, PartialEq)]
+pub enum Target {
+    CortexM,
+    Msp430,
+    RISCV,
+    None,
+}


### PR DESCRIPTION
This makes it nice and easy for `cargo build` scripts to generate the source for SVD files, similar to the way that `bindgen` works.

For an example take a look at <https://github.com/dfrankland/mk20d7/blob/master/build.rs>