### PR TITLE
cortex-m: generate code that compiles on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,27 +12,38 @@ matrix:
   include:
     # Nightly, for testing
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Atmel
-      rust: nightly
+      rust: beta
+
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Freescale
-      rust: nightly
+      rust: beta
+
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Fujitsu
-      rust: nightly
+      rust: beta
+
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Holtek
-      rust: nightly
+      rust: beta
+
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Nordic
-      rust: nightly
+      rust: beta
+
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Nuvoton
-      rust: nightly
+      rust: beta
+
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=NXP
-      rust: nightly
+      rust: beta
+
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=SiliconLabs
-      rust: nightly
+      rust: beta
+
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Spansion
-      rust: nightly
+      rust: beta
+
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=STMicro
-      rust: nightly
+      rust: beta
+
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Toshiba
-      rust: nightly
+      rust: beta
+
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=OTHER
       rust: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,37 +12,26 @@ matrix:
   include:
     # Nightly, for testing
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Atmel
-      rust: beta
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Freescale
-      rust: beta
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Fujitsu
-      rust: beta
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Holtek
-      rust: beta
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Nordic
-      rust: beta
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Nuvoton
-      rust: beta
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=NXP
-      rust: beta
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=SiliconLabs
-      rust: beta
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Spansion
-      rust: beta
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=STMicro
-      rust: beta
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Toshiba
-      rust: beta
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=OTHER
       rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = [
 license = "MIT OR Apache-2.0"
 name = "svd2rust"
 repository = "https://github.com/japaric/svd2rust"
-version = "0.12.1"
+version = "0.13.0"
 
 [[bin]]
 doc = false

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -19,14 +19,7 @@ main() {
            --git japaric/cross \
            --tag $tag
 
-    if [ ! -z ${VENDOR-} ]; then
-        curl -LSfs https://japaric.github.io/trust/install.sh | \
-            sh -s -- \
-               --crate rustfmt \
-               --force \
-               --git japaric/rustfmt-bin \
-               --tag v0.8.4-20170605
-    fi
+    rustup component add rustfmt-preview
 }
 
 main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -14,7 +14,8 @@ test_svd() {
 
     mv lib.rs src/lib.rs
 
-    rustfmt src/lib.rs
+    # ignore rustfmt errors
+    rustfmt src/lib.rs || true
     popd
 
     cargo check --manifest-path $td/Cargo.toml

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -8,8 +8,14 @@ test_svd() {
     )
 
     # NOTE we care about errors in svd2rust, but not about errors / warnings in rustfmt
-    target/$TARGET/release/svd2rust -i $td/${1}.svd | \
-        ( rustfmt 2>/dev/null > $td/src/lib.rs || true )
+    local cwd=$(pwd)
+    pushd $td
+    $cwd/target/$TARGET/release/svd2rust -i ${1}.svd
+
+    mv lib.rs src/lib.rs
+
+    rustfmt src/lib.rs
+    popd
 
     cargo check --manifest-path $td/Cargo.toml
 }
@@ -34,18 +40,17 @@ main() {
 
     # test crate
     cargo init --name foo $td
-    echo 'bare-metal = "0.1.0"' >> $td/Cargo.toml
-    echo 'cortex-m = "0.4.0"' >> $td/Cargo.toml
-    echo 'cortex-m-rt = "0.3.0"' >> $td/Cargo.toml
+    echo 'cortex-m = "0.5.0"' >> $td/Cargo.toml
+    echo 'cortex-m-rt = "0.5.0"' >> $td/Cargo.toml
     echo 'vcell = "0.1.0"' >> $td/Cargo.toml
-    echo 'msp430 = "0.1.0"' >> $td/Cargo.toml
-    # echo 'riscv = "0.1.4"' >> $td/Cargo.toml
-    # echo 'riscv-rt = "0.1.3"' >> $td/Cargo.toml
     echo '[profile.dev]' >> $td/Cargo.toml
     echo 'incremental = false' >> $td/Cargo.toml
 
     case $VENDOR in
         Atmel)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
             # BAD-SVD missing resetValue
             # test_svd AT91SAM9CN11
             # test_svd AT91SAM9CN12
@@ -129,6 +134,9 @@ main() {
         ;;
 
         Freescale)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
             # BAD-SVD bad enumeratedValue value
             # test_svd MKV56F20
             # test_svd MKV56F22
@@ -277,6 +285,9 @@ main() {
         ;;
 
         Fujitsu)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
             # OK
             test_svd MB9AF10xN
             test_svd MB9AF10xR
@@ -381,6 +392,9 @@ main() {
         ;;
 
         Holtek)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
             # OK
             test_svd ht32f125x
             test_svd ht32f175x
@@ -389,6 +403,18 @@ main() {
 
         # test other targets (architectures)
         OTHER)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.1.0"' >> $td/Cargo.toml
+
+            echo '[dependencies.msp430]' >> $td/Cargo.toml
+            echo 'version = "0.1.0"' >> $td/Cargo.toml
+
+            # echo '[dependencies.riscv]' >> $td/Cargo.toml
+            # echo 'version = "0.2.0"' >> $td/Cargo.toml
+
+            # echo '[dependencies.riscv-rt]' >> $td/Cargo.toml
+            # echo 'version = "0.2.0"' >> $td/Cargo.toml
+
             (
                 cd $td &&
                     curl -LO \
@@ -415,6 +441,9 @@ main() {
         ;;
 
         Nordic)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
             # BAD-SVD two enumeratedValues have the same value
             # test_svd nrf52
 
@@ -423,12 +452,18 @@ main() {
         ;;
 
         Nuvoton)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
             # OK
             test_svd M051_Series
             test_svd NUC100_Series
         ;;
 
         NXP)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
             # BAD-SVD two enumeratedValues have the same name
             # test_svd LPC11Exx_v5
             # test_svd LPC11Uxx_v7
@@ -465,6 +500,9 @@ main() {
         ;;
 
         SiliconLabs)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
             # #99 regression tests
             test_svd SIM3C1x4_SVD
             test_svd SIM3C1x6_SVD
@@ -481,6 +519,9 @@ main() {
         ;;
 
         Spansion)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
             # OK
             test_svd MB9AF12xK
             test_svd MB9AF12xL
@@ -576,6 +617,9 @@ main() {
         ;;
 
         STMicro)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
             # OK
             test_svd STM32F030
             test_svd STM32F031x
@@ -626,6 +670,9 @@ main() {
         ;;
 
         Toshiba)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
             # BAD-SVD resetValue is bigger than the register size
             # test_svd M365
             # test_svd M367

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -113,18 +113,10 @@ pub fn render(d: &Device, target: &Target, nightly: bool, device_x: &mut String)
             pub use cortex_m::peripheral::Peripherals as CorePeripherals;
         });
 
-        // NOTE re-export only core peripherals available on *all* Cortex-M devices
-        // (if we want to re-export all core peripherals available for the target then we are going
-        // to need to replicate the `#[cfg]` stuff that cortex-m uses and that would require all
-        // device crates to define the custom `#[cfg]`s that cortex-m uses in their build.rs ...)
         out.push(quote! {
-            pub use cortex_m::peripheral::CPUID;
-            pub use cortex_m::peripheral::DCB;
-            pub use cortex_m::peripheral::DWT;
-            pub use cortex_m::peripheral::MPU;
-            pub use cortex_m::peripheral::NVIC;
-            pub use cortex_m::peripheral::SCB;
-            pub use cortex_m::peripheral::SYST;
+            pub use cortex_m::peripheral::{
+                CBP, CPUID, DCB, DWT, FPB, FPU, ITM, MPU, NVIC, SCB, SYST, TPIU,
+            };
         });
     }
 
@@ -133,7 +125,6 @@ pub fn render(d: &Device, target: &Target, nightly: bool, device_x: &mut String)
             // Core peripherals are handled above
             continue;
         }
-
 
         out.extend(peripheral::render(p, &d.peripherals, &d.defaults, nightly)?);
 

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -9,7 +9,7 @@ use Target;
 use generate::{interrupt, peripheral};
 
 /// Whole device generation
-pub fn render(d: &Device, target: &Target, nightly: bool) -> Result<Vec<Tokens>> {
+pub fn render(d: &Device, target: &Target, nightly: bool, device_x: &mut String) -> Result<Vec<Tokens>> {
     let mut out = vec![];
 
     let doc = format!(
@@ -42,6 +42,13 @@ pub fn render(d: &Device, target: &Target, nightly: bool) -> Result<Vec<Tokens>>
         #![allow(non_camel_case_types)]
         #![no_std]
     });
+
+    if *target != Target::CortexM {
+        out.push(quote! {
+            #![feature(const_fn)]
+            #![feature(try_From)]
+        });
+    }
 
     if nightly {
         out.push(quote! {
@@ -93,7 +100,7 @@ pub fn render(d: &Device, target: &Target, nightly: bool) -> Result<Vec<Tokens>>
         });
     }
 
-    out.extend(interrupt::render(target, &d.peripherals)?);
+    out.extend(interrupt::render(target, &d.peripherals, device_x)?);
 
     const CORE_PERIPHERALS: &[&str] = &[
         "CBP", "CPUID", "DCB", "DWT", "FPB", "FPU", "ITM", "MPU", "NVIC", "SCB", "SYST", "TPIU"

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -100,11 +100,33 @@ pub fn render(
                 ];
 
                 /// Macro to override a device specific interrupt handler
+                ///
+                /// # Syntax
+                ///
+                /// ``` ignore
+                /// interrupt!(
+                ///     // Name of the interrupt
+                ///     $Name:ident,
+                ///
+                ///     // Path to the interrupt handler (a function)
+                ///     $handler:path,
+                ///
+                ///     // Optional, state preserved across invocations of the handler
+                ///     state: $State:ty = $initial_state:expr,
+                /// );
+                /// ```
+                ///
+                /// Where `$Name` must match the name of one of the variants of the `Interrupt`
+                /// enum.
+                ///
+                /// The handler must have signature `fn()` is no state was associated to it;
+                /// otherwise its signature must be `fn(&mut $State)`.
                 #[cfg(feature = "rt")]
                 #[macro_export]
                 macro_rules! interrupt {
                     ($Name:ident, $handler:path,state: $State:ty = $initial_state:expr) => {
                         #[allow(unsafe_code)]
+                        #[deny(private_no_mangle_fns)] // raise an error if this item is not accessible
                         #[no_mangle]
                         pub unsafe extern "C" fn $Name() {
                             static mut STATE: $State = $initial_state;
@@ -121,6 +143,7 @@ pub fn render(
 
                     ($Name:ident, $handler:path) => {
                         #[allow(unsafe_code)]
+                        #[deny(private_no_mangle_fns)] // raise an error if this item is not accessible
                         #[no_mangle]
                         pub unsafe extern "C" fn $Name() {
                             // check that this interrupt exists

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use cast::u64;
 use quote::Tokens;
-use svd::{Device, Peripheral};
+use svd::Peripheral;
 use syn::Ident;
 
 use errors::*;
@@ -10,7 +10,7 @@ use util::{self, ToSanitizedUpperCase};
 use Target;
 
 /// Generates code for `src/interrupt.rs`
-pub fn render(device: &Device, target: &Target, peripherals: &[Peripheral]) -> Result<Vec<Tokens>> {
+pub fn render(target: &Target, peripherals: &[Peripheral]) -> Result<Vec<Tokens>> {
     let interrupts = peripherals
         .iter()
         .flat_map(|p| p.interrupt.iter())
@@ -20,6 +20,7 @@ pub fn render(device: &Device, target: &Target, peripherals: &[Peripheral]) -> R
     let mut interrupts = interrupts.into_iter().map(|(_, v)| v).collect::<Vec<_>>();
     interrupts.sort_by_key(|i| i.value);
 
+    let mut root = vec![];
     let mut arms = vec![];
     let mut from_arms = vec![];
     let mut elements = vec![];
@@ -29,9 +30,6 @@ pub fn render(device: &Device, target: &Target, peripherals: &[Peripheral]) -> R
     // Current position in the vector table
     let mut pos = 0;
     let mut mod_items = vec![];
-    mod_items.push(quote! {
-        use bare_metal::Nr;
-    });
     for interrupt in &interrupts {
         while pos < interrupt.value {
             elements.push(quote!(None));
@@ -85,63 +83,17 @@ pub fn render(device: &Device, target: &Target, peripherals: &[Peripheral]) -> R
     let n = util::unsuffixed(u64(pos));
     match *target {
         Target::CortexM => {
-            let is_armv6 = match device.cpu {
-                Some(ref cpu) => cpu.name.starts_with("CM0"),
-                None => true, // default to armv6 when the <cpu> section is missing
-            };
-
-            if is_armv6 {
-                // Cortex-M0(+) are ARMv6 and don't have `b.w` (branch with 16 MB range). This
-                // can cause linker errors when the handler is too far away. Instead of a small
-                // inline assembly shim, we generate a function for those targets and let the
-                // compiler do the work (sacrificing a few bytes of code).
-                mod_items.push(quote! {
-                    #[cfg(feature = "rt")]
-                    extern "C" {
-                        fn DEFAULT_HANDLER();
-                    }
-
-                    #[cfg(feature = "rt")]
-                    #[allow(non_snake_case)]
-                    #[no_mangle]
-                    pub unsafe extern "C" fn DH_TRAMPOLINE() {
-                        DEFAULT_HANDLER();
-                    }
-                });
-            } else {
-                mod_items.push(quote! {
-                    #[cfg(all(target_arch = "arm", feature = "rt"))]
-                    global_asm!("
-                    .thumb_func
-                    DH_TRAMPOLINE:
-                        b DEFAULT_HANDLER
-                    ");
-
-                    /// Hack to compile on x86
-                    #[cfg(all(target_arch = "x86_64", feature = "rt"))]
-                    global_asm!("
-                    DH_TRAMPOLINE:
-                        jmp DEFAULT_HANDLER
-                    ");
-                })
-            }
-
-            mod_items.push(quote! {
-                #[cfg(feature = "rt")]
-                global_asm!(#aliases);
-
+            root.push(quote! {
                 #[cfg(feature = "rt")]
                 extern "C" {
                     #(fn #names();)*
                 }
 
-                #[allow(private_no_mangle_statics)]
                 #[cfg(feature = "rt")]
                 #[doc(hidden)]
                 #[link_section = ".vector_table.interrupts"]
                 #[no_mangle]
-                #[used]
-                pub static INTERRUPTS: [Option<unsafe extern "C" fn()>; #n] = [
+                pub static __INTERRUPTS: [Option<unsafe extern "C" fn()>; #n] = [
                     #(#elements,)*
                 ];
             });
@@ -178,13 +130,13 @@ pub fn render(device: &Device, target: &Target, peripherals: &[Peripheral]) -> R
         Target::None => {}
     }
 
-    mod_items.push(quote! {
+    let interrupt_enum = quote! {
         /// Enumeration of all the interrupts
         pub enum Interrupt {
             #(#variants)*
         }
 
-        unsafe impl Nr for Interrupt {
+        unsafe impl ::bare_metal::Nr for Interrupt {
             #[inline]
             fn nr(&self) -> u8 {
                 match *self {
@@ -192,92 +144,103 @@ pub fn render(device: &Device, target: &Target, peripherals: &[Peripheral]) -> R
                 }
             }
         }
+    };
 
-        use core::convert::TryFrom;
+    if *target == Target::CortexM {
+        root.push(interrupt_enum);
+    } else {
+        mod_items.push(quote! {
+            use core::convert::TryFrom;
 
-        #[derive(Debug, Copy, Clone)]
-        pub struct TryFromInterruptError(());
+            #[derive(Debug, Copy, Clone)]
+            pub struct TryFromInterruptError(());
 
-        impl TryFrom<u8> for Interrupt {
-            type Error = TryFromInterruptError;
+            impl TryFrom<u8> for Interrupt {
+                type Error = TryFromInterruptError;
 
-            #[inline]
-            fn try_from(value: u8) -> Result<Self, Self::Error> {
-                match value {
-                    #(#from_arms)*
-                    _ => Err(TryFromInterruptError(())),
+                #[inline]
+                fn try_from(value: u8) -> Result<Self, Self::Error> {
+                    match value {
+                        #(#from_arms)*
+                        _ => Err(TryFromInterruptError(())),
+                    }
                 }
             }
-        }
-    });
+        });
+    }
 
     if *target != Target::None {
         let abi = match *target {
             Target::Msp430 => "msp430-interrupt",
             _ => "C",
         };
-        mod_items.push(quote! {
-            #[cfg(feature = "rt")]
-            #[macro_export]
-            macro_rules! interrupt {
-                ($NAME:ident, $path:path, locals: {
-                    $($lvar:ident:$lty:ty = $lval:expr;)*
-                }) => {
-                    #[allow(non_snake_case)]
-                    mod $NAME {
-                        pub struct Locals {
-                            $(
-                                pub $lvar: $lty,
-                            )*
+
+        if *target != Target::CortexM {
+            mod_items.push(quote! {
+                #[cfg(feature = "rt")]
+                #[macro_export]
+                macro_rules! interrupt {
+                    ($NAME:ident, $path:path, locals: {
+                        $($lvar:ident:$lty:ty = $lval:expr;)*
+                    }) => {
+                        #[allow(non_snake_case)]
+                        mod $NAME {
+                            pub struct Locals {
+                                $(
+                                    pub $lvar: $lty,
+                                )*
+                            }
+                        }
+
+                        #[allow(non_snake_case)]
+                        #[no_mangle]
+                        pub extern #abi fn $NAME() {
+                            // check that the handler exists
+                            let _ = $crate::interrupt::Interrupt::$NAME;
+
+                            static mut LOCALS: self::$NAME::Locals =
+                                self::$NAME::Locals {
+                                    $(
+                                        $lvar: $lval,
+                                    )*
+                                };
+
+                            // type checking
+                            let f: fn(&mut self::$NAME::Locals) = $path;
+                            f(unsafe { &mut LOCALS });
+                        }
+                    };
+                    ($NAME:ident, $path:path) => {
+                        #[allow(non_snake_case)]
+                        #[no_mangle]
+                        pub extern #abi fn $NAME() {
+                            // check that the handler exists
+                            let _ = $crate::interrupt::Interrupt::$NAME;
+
+                            // type checking
+                            let f: fn() = $path;
+                            f();
                         }
                     }
-
-                    #[allow(non_snake_case)]
-                    #[no_mangle]
-                    pub extern #abi fn $NAME() {
-                        // check that the handler exists
-                        let _ = $crate::interrupt::Interrupt::$NAME;
-
-                        static mut LOCALS: self::$NAME::Locals =
-                            self::$NAME::Locals {
-                                $(
-                                    $lvar: $lval,
-                                )*
-                            };
-
-                        // type checking
-                        let f: fn(&mut self::$NAME::Locals) = $path;
-                        f(unsafe { &mut LOCALS });
-                    }
-                };
-                ($NAME:ident, $path:path) => {
-                    #[allow(non_snake_case)]
-                    #[no_mangle]
-                    pub extern #abi fn $NAME() {
-                        // check that the handler exists
-                        let _ = $crate::interrupt::Interrupt::$NAME;
-
-                        // type checking
-                        let f: fn() = $path;
-                        f();
-                    }
                 }
-            }
-        });
+            });
+        }
     }
 
-    let mut out = vec![];
-
     if interrupts.len() > 0 {
-        out.push(quote! {
-            pub use interrupt::Interrupt;
-
+        root.push(quote! {
             #[doc(hidden)]
             pub mod interrupt {
                 #(#mod_items)*
             }
         });
+
+        if *target != Target::CortexM {
+            root.push(quote! {
+                pub use interrupt::Interrupt;
+            });
+        }
     }
 
-    Ok(out)
+    Ok(root)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,6 +426,12 @@
 
 /// Assigns a handler to an interrupt
 ///
+/// **NOTE** The `interrupt!` macro on Cortex-M device crates is closer in syntax to the
+/// [`exception!`] macro. This documentation doesn't apply to it. For the exact syntax of this macro
+/// check the documentation of the device crate you are using.
+///
+/// [`exception!`]: https://docs.rs/cortex-m-rt/0.5.0/cortex_m_rt/macro.exception.html
+///
 /// This macro takes two arguments: the name of an interrupt and the path to the
 /// function that will be used as the handler of that interrupt. That function
 /// must have signature `fn()`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,87 +18,92 @@
 //!
 //! # Usage
 //!
-//! `svd2rust` supports Cortex-M and MSP430 microcontrollers. The generated
-//! crate can be tailored for either architecture using the `--target` flag. The
-//! flag accepts "cortex-m", "msp430" and "none" as values. "none" can be used
-//! to generate a crate that's architecture agnostic and that should work for
-//! architectures that `svd2rust` doesn't currently know about like the Cortex-A
-//! architecture.
+//! `svd2rust` supports Cortex-M, MSP430 and RISCV microcontrollers. The generated crate can be
+//! tailored for either architecture using the `--target` flag. The flag accepts "cortex-m",
+//! "msp430", "riscv" and "none" as values. "none" can be used to generate a crate that's
+//! architecture agnostic and that should work for architectures that `svd2rust` doesn't currently
+//! know about like the Cortex-A architecture.
 //!
-//! If the `--target` flag is omitted `svd2rust` assumes the target is the
-//! Cortex-M architecture.
+//! If the `--target` flag is omitted `svd2rust` assumes the target is the Cortex-M architecture.
 //!
-//! ```
-//! $ svd2rust -i STM32F30x.svd | rustfmt | tee src/lib.rs
-//! //! Peripheral access API for STM32F30X microcontrollers
-//! //! (generated using svd2rust v0.12.0)
+//! ## target = cortex-m
 //!
-//! #![deny(missing_docs)]
-//! #![deny(warnings)]
-//! #![no_std]
+//! When targeting the Cortex-M architecture `svd2rust` will generate three files in the current
+//! directory:
 //!
-//! extern crate bare_metal;
-//! extern crate cortex_m;
-//! #[cfg(feature = "rt")]
-//! extern crate cortex_m_rt;
-//! extern crate vcell;
+//! - build.rs
+//! - device.x
+//! - lib.rs
 //!
-//! use cortex_m::peripheral::Peripheral;
+//! All these files must be included in the same device crate. The `lib.rs` file contains several
+//! inlined modules and its not formatted. It's recommend to split it out using the [`form`] tool
+//! and then format the output using `rustfmt` / `cargo fmt`:
 //!
-//! /// Interrupts
-//! pub mod interrupt {
-//!     // ..
-//! }
+//! [`form`]: https://crates.io/crates/form
 //!
-//! /// General-purpose I/Os
-//! pub mod gpioa {
-//!     pub struct RegisterBlock {
-//!         /// GPIO port mode register
-//!         pub moder: MODER,
-//!         ..
-//!     }
-//!     ..
-//! }
+//! ``` text
+//! $ svd2rust -i STM32F30x.svd
 //!
-//! /// General-purpose I/Os
-//! pub struct GPIOA { _marker: PhantomData<*const ()> }
+//! $ rm -rf src
 //!
-//! unsafe impl Send for GPIOA {}
+//! $ form -i lib.rs -o src/ && rm lib.rs
 //!
-//! impl GPIOA {
-//!     /// Returns a pointer to the register block
-//!     pub fn ptr() -> *const gpioa::RegisterBlock {
-//!         0x4800_0000 as *const _
-//!     }
-//! }
-//!
-//! impl core::ops::Deref for GPIOA {
-//!     type Target = gpioa::RegisterBlock;
-//!
-//!     fn deref(&self) -> &gpioa::RegisterBlock {
-//!         unsafe { &*GPIOA::ptr() }
-//!     }
-//! }
-//!
-//! // ..
+//! $ cargo fmt
 //! ```
 //!
-//! # Dependencies
+//! The resulting crate must provide an opt-in "rt" feature and depend on these crates:
+//! `bare-metal` v0.2.x, `cortex-m` v0.5.x, `cortex-m-rt` v0.5.x and `vcell` v0.1.x. Furthermore the
+//! "device" feature of `cortex-m-rt` must be enabled when the "rt" feature is enabled. The
+//! `Cargo.toml` of the device crate will look like this:
 //!
-//! The generated crate depends on:
+//! ``` toml
+//! [dependencies]
+//! bare-metal = "0.2.0"
+//! cortex-m = "0.5.0"
+//! cortex-m-rt = "0.5.0"
+//! vcell = "0.1.0"
+//!
+//! [features]
+//! rt = ["cortex-m-rt/device"]
+//! ```
+//!
+//! ## target != cortex-m
+//!
+//! When the target is msp430, riscv or none `svd2rust` will emit all the generated code to stdout.
+//! Like in the cortex-m case we recommend you use `form` and `rustfmt` on the output:
+//!
+//! ``` console
+//! $ svd2rust -i *.svd --target msp430 > lib.rs
+//!
+//! $ rm -rf src
+//!
+//! $ form -i lib.rs -o src/ && rm lib.rs
+//!
+//! $ cargo fmt
+//! ```
+//!
+//! The resulting crate must provide an opt-in "rt" feature and depend on these crates:
 //!
 //! - [`bare-metal`](https://crates.io/crates/bare-metal) v0.1.x
 //! - [`vcell`](https://crates.io/crates/vcell) v0.1.x
-//! - [`cortex-m-rt`](https://crates.io/crates/cortex-m-rt) v0.3.x if targeting
-//!   the Cortex-M architecture.
-//! - [`cortex-m`](https://crates.io/crates/cortex-m) v0.4.x if targeting the
-//!   Cortex-M architecture.
-//! - [`msp430`](https://crates.io/crates/msp430) v0.1.x if targeting the MSP430
-//!   architecture.
-//! - [`msp430-rt`](https://crates.io/crates/msp430-rt) v0.1.x if targeting the
-//!   MSP430 architecture.
-//! - [`riscv-rt`](https://crates.io/crates/riscv-rt) v0.2.x if targeting the
-//!   RISCV architecture.
+//! - [`msp430`](https://crates.io/crates/msp430) v0.1.x if target = msp430.
+//! - [`msp430-rt`](https://crates.io/crates/msp430-rt) v0.1.x if target = msp430.
+//! - [`riscv`](https://crates.io/crates/riscv) v0.2.x if target = riscv.
+//! - [`riscv-rt`](https://crates.io/crates/riscv-rt) v0.2.x if target = riscv.
+//!
+//! The `*-rt` dependencies must be optional only enabled when the "rt" feature is enabled. The
+//! `Cargo.toml` of the device crate will look like this for an msp430 target:
+//!
+//! ``` toml
+//! [dependencies]
+//! bare-metal = "0.2.0"
+//! msp430 = "0.1.0"
+//! msp430-rt = "0.1.0"
+//! vcell = "0.1.0"
+//!
+//! [features]
+//! rt = ["msp430"]
+//! ```
 //!
 //! # Peripheral API
 //!
@@ -409,12 +414,12 @@
 //! If the "rt" Cargo feature of the svd2rust generated crate is enabled the crate will populate the
 //! part of the vector table that contains the interrupt vectors and provide an
 //! [`interrupt!`](macro.interrupt.html) macro that can be used to register interrupt handlers.
-//! 
+//!
 //! ## the `--nightly` flag
 //!
 //! The `--nightly` flag can be passed to `svd2rust` to enable features in the generated api that are only available to a nightly
 //! compiler. These features are
-//! 
+//!
 //! - `#[feature(untagged_unions)]` for overlapping/overloaded registers
 
 // NOTE This file is for documentation only


### PR DESCRIPTION
This is still missing some stuff:

- svd2rust must now generate an interrupts.x linker script and a build script that puts the linker script somewhere the linker can find it. See japaric/stm32f103xx#24 for a sample of what those files look like.

- we have to decide how to organize the svd2rust output. It probably makes sense to generate 3 files on $PWD (lib.rs, build.rs, interrupts.x) for Cortex-M and a single lib.rs for the other targets.

- I probably broke the other targets; need to test them