### PR TITLE
Revert PR 201 "Expose internals to lib"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,25 +410,6 @@
 
 // NOTE This file is for documentation only
 
-#![recursion_limit = "128"]
-
-extern crate cast;
-extern crate either;
-#[macro_use]
-extern crate error_chain;
-extern crate inflections;
-#[macro_use]
-pub extern crate quote;
-pub extern crate svd_parser as svd;
-extern crate syn;
-
-mod errors;
-pub mod generate;
-mod util;
-pub mod target;
-
-use target::Target;
-
 /// Assigns a handler to an interrupt
 ///
 /// This macro takes two arguments: the name of an interrupt and the path to the

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ extern crate syn;
 mod errors;
 mod generate;
 mod util;
-mod target;
 
 use std::fs::File;
 use std::{io, process};
@@ -22,7 +21,14 @@ use std::{io, process};
 use clap::{App, Arg};
 
 use errors::*;
-use target::Target;
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum Target {
+    CortexM,
+    Msp430,
+    RISCV,
+    None,
+}
 
 impl Target {
     fn parse(s: &str) -> Result<Self> {

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,7 +1,0 @@
-#[derive(Clone, Copy, PartialEq)]
-pub enum Target {
-    CortexM,
-    Msp430,
-    RISCV,
-    None,
-}


### PR DESCRIPTION
This reverts commit 93148049b56d15af3a1f598d1df7ad120ef8449e.

I'd rather not make this API public; it forces semver on us and we would have to bump the minor
version more often. For example, we would have to bump the minor version whenever we change the API
of `generate::{interrupt,..,register}::render`, which happens to be a pretty big API surface as it
includes structs from the `svd` and the `syn` crates so if we (minor version) bump any of those
dependencies then we have to bump the minor version of `svd2rust` as well.

Also the more often we bump minor versions the more work we give to device crate authors: now when
they re-generate their device crates they have to check if the minor version actually broke the
generated API or if it just was due to change in the API of `svd2rust`, the library.

If we want to expose some API to turn SVD files into Rust code in build scripts (which I think it's
a bad idea (\*)) we should expose a single function that takes a string in (the SVD file) and
returns a string (the Rust code).

(\*) It forces all your users (both direct and indirect) to (re-)build `svd2rust` (which
takes non trivial amount of time) for *every* one of their Cargo projects that depends on your
crate. And for no gain whatsoever because the output of `svd2rust` depends only on the input SVD and
not on the build environment (unlike say running `bindgen` on C headers installed in `/usr`) so it's
just a waste of CPU cycles. It's better to cache the output of `svd2rust` in the device crate, IMO.

r? @Emilgardis 
cc @dfrankland 