### PR TITLE
Add `'/'`, `' '` to `BLACKLIST_CHARS`

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -12,7 +12,7 @@ pub const BITS_PER_BYTE: u32 = 8;
 
 /// List of chars that some vendors use in their peripheral/field names but
 /// that are not valid in Rust ident
-const BLACKLIST_CHARS: &'static [char] = &['(', ')', '[', ']'];
+const BLACKLIST_CHARS: &'static [char] = &['(', ')', '[', ']', '/', ' '];
 
 pub trait ToSanitizedPascalCase {
     fn to_sanitized_pascal_case(&self) -> Cow<str>;


### PR DESCRIPTION
These characters occur in [the .svd file for NXP LPC13xx](https://github.com/posborne/cmsis-svd/blob/master/data/NXP/LPC13xx_svd_v1.svd).