### PR TITLE
registers_with_uniq_names

### DIFF
--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -732,11 +732,15 @@ fn cluster_block(
     let reg_block = register_or_cluster_block(&c.children, defaults, Some(&mod_name), nightly)?;
 
     // Generate definition for each of the registers.
-    let registers = util::only_registers(&c.children);
+    let registers_cow = util::registers_with_uniq_names(
+        util::only_registers(&c.children)
+            .into_iter()
+    );
+    let registers: Vec<&Register> = registers_cow.iter().map(|cow| &**cow).collect();
     for reg in &registers {
         mod_items.extend(register::render(
             reg,
-            &registers,
+            &registers[..],
             p,
             all_peripherals,
             defaults,


### PR DESCRIPTION
Here is a proposal to solve one more issue I found in the [LPC13xx .svd file](https://github.com/posborne/cmsis-svd/blob/master/data/NXP/LPC13xx_svd_v1.svd): registers with duplicate names.

This PR does not simply drop the duplicate identifiers but tries to rename them by appending `2`, or `3`, and so on.